### PR TITLE
[Design] Modernize Built with Django UI

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,33 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+Built with Django serves Django-curious builders, indie hackers, students, working developers, founders, hiring teams, and makers who want to see what real Django products look like in the wild. Visitors are usually exploring, learning, validating an idea, looking for examples, hiring Django talent, or deciding whether Django is a serious choice for their next project.
+
+## Product Purpose
+
+Built with Django is a community showcase and learning hub for projects, guides, jobs, developers, and makers in the Django ecosystem. It should help people discover useful examples, learn from the community, and eventually convert high-intent traffic into paid offers without making the site feel transactional too early.
+
+## Brand Personality
+
+Friendly, practical, community-led. The tone should feel like a useful indie developer resource run by a real person, not a generic SaaS landing page or a corporate developer portal.
+
+## Anti-references
+
+Avoid generic AI-generated SaaS design: gradient blobs, identical feature-card grids, decorative hero metrics, generic "modern" startup polish, and vague marketing copy. Avoid making Django feel childish or unserious through overplayed green branding. Avoid hiding the community and project screenshots behind abstract decoration.
+
+## Design Principles
+
+1. Lead with useful proof: real projects, real guides, real jobs, real people.
+2. Make discovery feel alive: visitors should quickly understand where to browse, learn, submit, hire, or subscribe.
+3. Keep the community human: make the site feel curated by a person and powered by builders.
+4. Earn future monetization: make high-intent actions visible without making every page feel like an ad.
+5. Respect mobile browsing: project cards, filters, navigation, content, and calls to action must work well one-handed.
+
+## Accessibility & Inclusion
+
+Target WCAG AA for contrast, keyboard focus, semantic structure, and touch target sizing. Support reduced motion. Keep copy clear for non-native English readers and beginners learning Django.

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -359,12 +359,55 @@
   }
 
   .bw-hero-placeholder {
+    display: flex;
     min-height: 14rem;
+    flex-direction: column;
+    justify-content: space-between;
     border: 1px solid var(--bw-border);
     border-radius: var(--bw-radius);
     background: var(--bw-surface);
     padding: 1.15rem;
     box-shadow: var(--bw-shadow-sm);
+    color: var(--bw-ink);
+    text-decoration: none;
+    transition:
+      transform 180ms var(--bw-ease),
+      border-color 180ms var(--bw-ease),
+      box-shadow 180ms var(--bw-ease);
+  }
+
+  .bw-hero-placeholder__action {
+    display: inline-flex;
+    width: fit-content;
+    max-width: 100%;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 1rem;
+    border-radius: var(--bw-radius);
+    color: var(--bw-primary-dark);
+    font-size: 0.9rem;
+    font-weight: 850;
+    line-height: 1.2;
+  }
+
+  @media (hover: hover) {
+    .bw-hero-placeholder:hover {
+      border-color: var(--bw-primary);
+      box-shadow: var(--bw-shadow);
+      transform: translateY(-2px);
+    }
+
+    .bw-hero-placeholder:hover .bw-hero-placeholder__action {
+      color: var(--bw-ink);
+    }
+
+    .bw-hero-placeholder.sm\:translate-y-6:hover {
+      transform: translateY(1.25rem);
+    }
+
+    .bw-hero-placeholder.sm\:-translate-y-6:hover {
+      transform: translateY(-1.75rem);
+    }
   }
 
   .bw-proof-strip {

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -552,6 +552,74 @@
     color: var(--bw-accent);
   }
 
+  .bw-webring-shell {
+    width: min(100% - 2rem, 72rem);
+    margin-inline: auto;
+    border-top: 1px solid oklch(35% 0.035 156);
+    padding-top: clamp(1.4rem, 4vw, 2.5rem);
+    padding-bottom: clamp(7.25rem, 13vw, 9.5rem);
+  }
+
+  .bw-webring-panel {
+    display: grid;
+    gap: 1.25rem;
+    align-items: center;
+    border: 1px solid oklch(35% 0.045 151);
+    border-radius: var(--bw-radius);
+    background:
+      linear-gradient(135deg, oklch(18% 0.045 151), oklch(13% 0.035 151)),
+      var(--bw-ink);
+    padding: clamp(1rem, 4vw, 1.4rem);
+    box-shadow: inset 0 1px 0 oklch(100% 0.01 118 / 0.08);
+  }
+
+  @media (min-width: 768px) {
+    .bw-webring-panel {
+      grid-template-columns: minmax(14rem, 0.9fr) minmax(0, 1.25fr);
+      gap: clamp(1.5rem, 5vw, 3rem);
+    }
+  }
+
+  .bw-webring-copy {
+    max-width: 28rem;
+  }
+
+  .bw-webring-label {
+    color: var(--bw-accent);
+    font-size: 0.74rem;
+    font-weight: 900;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    text-transform: uppercase;
+  }
+
+  .bw-webring-copy h2 {
+    margin-top: 0.7rem;
+    color: oklch(96% 0.025 126);
+    font-size: clamp(1.65rem, 4vw, 2.35rem);
+    font-weight: 900;
+    line-height: 0.98;
+  }
+
+  .bw-webring-copy p:not(.bw-webring-label) {
+    margin-top: 0.85rem;
+    color: oklch(78% 0.03 126);
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  .bw-webring-widget {
+    min-width: 0;
+    border-radius: var(--bw-radius);
+    background: oklch(11% 0.03 151);
+    padding: clamp(0.9rem, 3vw, 1.2rem);
+  }
+
+  .bw-webring-widget webring-css {
+    display: block;
+    min-width: 0;
+  }
+
   .btn-blue {
     @apply inline-flex items-center px-4 py-2 font-semibold text-white bg-blue-500 rounded-lg shadow-md;
     @apply hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75;

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -6,6 +6,99 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --bw-bg: oklch(96.5% 0.018 122);
+    --bw-bg-warm: oklch(98.3% 0.018 106);
+    --bw-surface: oklch(99% 0.008 118);
+    --bw-surface-raised: oklch(97.6% 0.012 118);
+    --bw-surface-muted: oklch(93.5% 0.022 124);
+    --bw-ink: oklch(20% 0.035 156);
+    --bw-ink-soft: oklch(34% 0.035 156);
+    --bw-muted: oklch(48% 0.026 156);
+    --bw-border: oklch(86% 0.025 126);
+    --bw-border-strong: oklch(76% 0.04 128);
+    --bw-primary: oklch(51% 0.15 151);
+    --bw-primary-dark: oklch(34% 0.12 151);
+    --bw-primary-soft: oklch(91% 0.055 147);
+    --bw-accent: oklch(82% 0.17 92);
+    --bw-accent-soft: oklch(94% 0.075 92);
+    --bw-blue: oklch(48% 0.13 238);
+    --bw-danger: oklch(55% 0.18 28);
+    --bw-radius: 0.5rem;
+    --bw-shadow-sm: 0 1px 2px oklch(25% 0.035 156 / 0.08);
+    --bw-shadow: 0 14px 34px oklch(25% 0.035 156 / 0.11);
+    --bw-ease: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  html {
+    min-height: 100%;
+    background: var(--bw-bg);
+    color: var(--bw-ink);
+    scroll-behavior: smooth;
+  }
+
+  body {
+    min-height: 100%;
+    background:
+      linear-gradient(90deg, oklch(88% 0.018 122 / 0.32) 1px, transparent 1px),
+      linear-gradient(0deg, oklch(88% 0.018 122 / 0.32) 1px, transparent 1px),
+      linear-gradient(180deg, var(--bw-bg-warm), var(--bw-bg));
+    background-size: 32px 32px, 32px 32px, auto;
+    color: var(--bw-ink);
+    font-family: ui-rounded, "Avenir Next", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-kerning: normal;
+  }
+
+  ::selection {
+    background: var(--bw-accent);
+    color: var(--bw-ink);
+  }
+
+  a {
+    color: inherit;
+  }
+
+  h1,
+  h2,
+  h3 {
+    text-wrap: balance;
+  }
+
+  p,
+  li {
+    text-wrap: pretty;
+  }
+
+  img {
+    max-width: 100%;
+  }
+
+  input,
+  select,
+  textarea {
+    border-color: var(--bw-border);
+    border-radius: var(--bw-radius);
+    color: var(--bw-ink);
+  }
+
+  input:focus,
+  select:focus,
+  textarea:focus {
+    border-color: var(--bw-primary);
+    box-shadow: 0 0 0 3px oklch(51% 0.15 151 / 0.18);
+  }
+
+  :focus {
+    outline: none;
+  }
+
+  :focus-visible {
+    outline: 3px solid var(--bw-accent);
+    outline-offset: 3px;
+  }
+}
+
 [data-turbo-preview] body {
   opacity: 0.5;
 }
@@ -17,11 +110,460 @@
 }
 
 @layer components {
+  .bw-container {
+    width: min(100% - 2rem, 72rem);
+    margin-inline: auto;
+  }
+
+  .bw-container-wide {
+    width: min(100% - 2rem, 82rem);
+    margin-inline: auto;
+  }
+
+  .bw-section {
+    padding-block: clamp(3rem, 7vw, 6rem);
+  }
+
+  .bw-surface {
+    background: var(--bw-surface);
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    box-shadow: var(--bw-shadow-sm);
+  }
+
+  .bw-card {
+    position: relative;
+    overflow: hidden;
+    background: var(--bw-surface);
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    box-shadow: var(--bw-shadow-sm);
+    transition:
+      transform 180ms var(--bw-ease),
+      border-color 180ms var(--bw-ease),
+      box-shadow 180ms var(--bw-ease);
+  }
+
+  @media (hover: hover) {
+    .bw-card:hover {
+      border-color: var(--bw-border-strong);
+      box-shadow: var(--bw-shadow);
+      transform: translateY(-2px);
+    }
+  }
+
+  .bw-button {
+    display: inline-flex;
+    min-height: 2.75rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border: 1px solid transparent;
+    border-radius: var(--bw-radius);
+    padding: 0.7rem 1rem;
+    font-weight: 750;
+    line-height: 1;
+    text-decoration: none;
+    transition:
+      transform 150ms var(--bw-ease),
+      background-color 150ms var(--bw-ease),
+      border-color 150ms var(--bw-ease),
+      color 150ms var(--bw-ease),
+      box-shadow 150ms var(--bw-ease);
+  }
+
+  .bw-button-primary {
+    background: var(--bw-primary-dark);
+    color: oklch(98% 0.01 118);
+    box-shadow: 0 10px 22px oklch(34% 0.12 151 / 0.2);
+  }
+
+  .bw-button-primary:hover {
+    background: var(--bw-primary);
+    color: oklch(99% 0.008 118);
+    transform: translateY(-1px);
+  }
+
+  .bw-button-secondary {
+    background: var(--bw-surface);
+    border-color: var(--bw-border);
+    color: var(--bw-ink);
+  }
+
+  .bw-button-secondary:hover {
+    background: var(--bw-primary-soft);
+    border-color: var(--bw-primary);
+  }
+
+  .bw-button-accent {
+    background: var(--bw-accent);
+    border-color: oklch(72% 0.15 92);
+    color: var(--bw-ink);
+  }
+
+  .bw-button-accent:hover {
+    background: oklch(78% 0.17 92);
+    transform: translateY(-1px);
+  }
+
+  .bw-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--bw-primary-dark);
+    font-size: 0.78rem;
+    font-weight: 850;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .bw-heading-xl {
+    color: var(--bw-ink);
+    font-size: clamp(3rem, 8vw, 6.6rem);
+    font-weight: 900;
+    letter-spacing: 0;
+    line-height: 0.92;
+  }
+
+  .bw-heading-lg {
+    color: var(--bw-ink);
+    font-size: clamp(2.2rem, 5vw, 4.25rem);
+    font-weight: 900;
+    letter-spacing: 0;
+    line-height: 0.98;
+  }
+
+  .bw-heading-md {
+    color: var(--bw-ink);
+    font-size: clamp(1.75rem, 3vw, 2.75rem);
+    font-weight: 850;
+    line-height: 1.05;
+  }
+
+  .bw-lede {
+    max-width: 42rem;
+    color: var(--bw-ink-soft);
+    font-size: clamp(1.05rem, 2vw, 1.35rem);
+    line-height: 1.55;
+  }
+
+  .bw-muted {
+    color: var(--bw-muted);
+  }
+
+  .bw-site-header {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    border-bottom: 1px solid var(--bw-border);
+    background: oklch(97.5% 0.016 118 / 0.94);
+    backdrop-filter: blur(14px);
+  }
+
+  .bw-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: var(--bw-ink);
+    font-weight: 850;
+    text-decoration: none;
+  }
+
+  .bw-brand img {
+    width: 2.55rem;
+    height: 2.55rem;
+  }
+
+  .bw-nav-link {
+    display: inline-flex;
+    min-height: 2.5rem;
+    align-items: center;
+    border-radius: var(--bw-radius);
+    padding-inline: 0.75rem;
+    color: var(--bw-ink-soft);
+    font-weight: 750;
+    text-decoration: none;
+  }
+
+  .bw-nav-link:hover {
+    background: var(--bw-primary-soft);
+    color: var(--bw-primary-dark);
+  }
+
+  .bw-menu-panel {
+    overflow: hidden;
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background: var(--bw-surface);
+    box-shadow: var(--bw-shadow);
+  }
+
+  .bw-menu-item {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.85rem;
+    color: var(--bw-ink);
+    text-decoration: none;
+  }
+
+  .bw-menu-item:hover {
+    background: var(--bw-primary-soft);
+  }
+
+  .bw-menu-icon {
+    display: inline-flex;
+    width: 2.25rem;
+    height: 2.25rem;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--bw-radius);
+    background: var(--bw-accent-soft);
+    color: var(--bw-primary-dark);
+    font-size: 1.3rem;
+  }
+
+  .bw-mobile-menu {
+    border-top: 1px solid var(--bw-border);
+    background: var(--bw-surface);
+  }
+
+  .bw-mobile-link {
+    display: flex;
+    min-height: 3rem;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--bw-border);
+    color: var(--bw-ink);
+    font-weight: 800;
+    text-decoration: none;
+  }
+
+  .bw-hero-showcase {
+    position: relative;
+    isolation: isolate;
+    padding: clamp(0.25rem, 2vw, 1rem);
+  }
+
+  .bw-hero-showcase::before {
+    position: absolute;
+    inset: 10% 0 8% 8%;
+    z-index: -1;
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background:
+      linear-gradient(135deg, oklch(99% 0.008 118), oklch(93.5% 0.035 133)),
+      var(--bw-surface);
+    box-shadow: var(--bw-shadow);
+    content: "";
+  }
+
+  .bw-hero-placeholder {
+    min-height: 14rem;
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background: var(--bw-surface);
+    padding: 1.15rem;
+    box-shadow: var(--bw-shadow-sm);
+  }
+
+  .bw-proof-strip {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background: var(--bw-surface);
+  }
+
+  .bw-proof-strip > * {
+    padding: 1rem;
+  }
+
+  .bw-proof-strip > * + * {
+    border-top: 1px solid var(--bw-border);
+  }
+
+  @media (min-width: 640px) {
+    .bw-proof-strip > * + * {
+      border-top: 0;
+      border-left: 1px solid var(--bw-border);
+    }
+  }
+
+  .bw-project-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    gap: 1rem;
+  }
+
+  .bw-empty-state {
+    border: 1px dashed var(--bw-border-strong);
+    border-radius: var(--bw-radius);
+    background: oklch(98.5% 0.012 118 / 0.7);
+    padding: clamp(1.25rem, 4vw, 2rem);
+  }
+
+  .bw-project-card {
+    display: flex;
+    min-height: 100%;
+    flex-direction: column;
+  }
+
+  .bw-project-card--sponsored {
+    border-color: oklch(76% 0.15 92);
+    box-shadow: 0 0 0 3px oklch(82% 0.17 92 / 0.32), var(--bw-shadow-sm);
+  }
+
+  .bw-project-card__media {
+    display: block;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+    border-bottom: 1px solid var(--bw-border);
+    background: var(--bw-surface-muted);
+  }
+
+  .bw-project-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: left top;
+    transition: transform 240ms var(--bw-ease);
+  }
+
+  @media (hover: hover) {
+    .bw-project-card:hover .bw-project-card__media img {
+      transform: scale(1.025);
+    }
+  }
+
+  .bw-project-card__body {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 0.7rem;
+    padding: 1rem;
+  }
+
+  .bw-project-card__title {
+    color: var(--bw-ink);
+    font-size: 1.12rem;
+    font-weight: 850;
+    line-height: 1.18;
+    text-decoration: none;
+  }
+
+  .bw-project-card__title:hover {
+    color: var(--bw-primary-dark);
+  }
+
+  .bw-project-card__actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-top: 1px solid var(--bw-border);
+    padding: 0.75rem 1rem;
+  }
+
+  .bw-icon-button {
+    display: inline-flex;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background: var(--bw-surface-raised);
+    color: var(--bw-ink-soft);
+    font-size: 1.25rem;
+    line-height: 1;
+    text-decoration: none;
+    transition:
+      background-color 150ms var(--bw-ease),
+      border-color 150ms var(--bw-ease),
+      color 150ms var(--bw-ease),
+      transform 150ms var(--bw-ease);
+  }
+
+  .bw-icon-button:hover {
+    border-color: var(--bw-primary);
+    background: var(--bw-primary-soft);
+    color: var(--bw-primary-dark);
+    transform: translateY(-1px);
+  }
+
+  .bw-page-hero {
+    padding-block: clamp(3rem, 7vw, 6rem);
+  }
+
+  .bw-toolbar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  @media (min-width: 768px) {
+    .bw-toolbar {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
+
+  .bw-search-input {
+    width: 100%;
+    min-height: 2.75rem;
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background: var(--bw-surface);
+    padding: 0.7rem 0.9rem;
+    color: var(--bw-ink);
+  }
+
+  @media (min-width: 768px) {
+    .bw-search-input {
+      width: 22rem;
+    }
+  }
+
+  .bw-prose {
+    color: var(--bw-ink-soft);
+  }
+
+  .bw-prose :where(h1, h2, h3, strong) {
+    color: var(--bw-ink);
+  }
+
+  .bw-prose :where(a) {
+    color: var(--bw-primary-dark);
+    font-weight: 750;
+    text-decoration-color: oklch(51% 0.15 151 / 0.45);
+    text-underline-offset: 0.16em;
+  }
+
+  .bw-footer {
+    border-top: 1px solid var(--bw-border);
+    background: var(--bw-ink);
+    color: oklch(91% 0.025 126);
+  }
+
+  .bw-footer a:hover {
+    color: var(--bw-accent);
+  }
+
   .btn-blue {
-    @apply inline-flex items-center;
-    @apply px-4 py-2;
-    @apply font-semibold rounded-lg shadow-md;
-    @apply text-white bg-blue-500;
+    @apply inline-flex items-center px-4 py-2 font-semibold text-white bg-blue-500 rounded-lg shadow-md;
     @apply hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -8,26 +8,26 @@
 
 @layer base {
   :root {
-    --bw-bg: oklch(96.5% 0.018 122);
-    --bw-bg-warm: oklch(98.3% 0.018 106);
-    --bw-surface: oklch(99% 0.008 118);
-    --bw-surface-raised: oklch(97.6% 0.012 118);
-    --bw-surface-muted: oklch(93.5% 0.022 124);
-    --bw-ink: oklch(20% 0.035 156);
-    --bw-ink-soft: oklch(34% 0.035 156);
-    --bw-muted: oklch(48% 0.026 156);
-    --bw-border: oklch(86% 0.025 126);
-    --bw-border-strong: oklch(76% 0.04 128);
-    --bw-primary: oklch(51% 0.15 151);
-    --bw-primary-dark: oklch(34% 0.12 151);
-    --bw-primary-soft: oklch(91% 0.055 147);
-    --bw-accent: oklch(82% 0.17 92);
-    --bw-accent-soft: oklch(94% 0.075 92);
-    --bw-blue: oklch(48% 0.13 238);
+    --bw-bg: oklch(94.5% 0.032 143);
+    --bw-bg-warm: oklch(97.3% 0.016 106);
+    --bw-surface: oklch(98.5% 0.012 112);
+    --bw-surface-raised: oklch(96.5% 0.018 126);
+    --bw-surface-muted: oklch(91.8% 0.03 138);
+    --bw-ink: oklch(18% 0.045 157);
+    --bw-ink-soft: oklch(31% 0.04 157);
+    --bw-muted: oklch(45% 0.03 157);
+    --bw-border: oklch(82% 0.036 134);
+    --bw-border-strong: oklch(67% 0.065 143);
+    --bw-primary: oklch(45% 0.13 151);
+    --bw-primary-dark: oklch(27% 0.09 154);
+    --bw-primary-soft: oklch(88% 0.06 145);
+    --bw-accent: oklch(79% 0.15 88);
+    --bw-accent-soft: oklch(93% 0.06 88);
+    --bw-blue: oklch(48% 0.11 231);
     --bw-danger: oklch(55% 0.18 28);
     --bw-radius: 0.5rem;
-    --bw-shadow-sm: 0 1px 2px oklch(25% 0.035 156 / 0.08);
-    --bw-shadow: 0 14px 34px oklch(25% 0.035 156 / 0.11);
+    --bw-shadow-sm: 0 1px 0 oklch(25% 0.035 156 / 0.08);
+    --bw-shadow: 0 12px 26px oklch(25% 0.04 156 / 0.12);
     --bw-ease: cubic-bezier(0.22, 1, 0.36, 1);
   }
 
@@ -41,10 +41,7 @@
   body {
     min-height: 100%;
     background:
-      linear-gradient(90deg, oklch(88% 0.018 122 / 0.32) 1px, transparent 1px),
-      linear-gradient(0deg, oklch(88% 0.018 122 / 0.32) 1px, transparent 1px),
-      linear-gradient(180deg, var(--bw-bg-warm), var(--bw-bg));
-    background-size: 32px 32px, 32px 32px, auto;
+      linear-gradient(180deg, oklch(97% 0.018 116) 0, oklch(94.5% 0.032 143) 28rem, oklch(92.8% 0.038 148) 56rem, oklch(95% 0.024 130) 100%);
     color: var(--bw-ink);
     font-family: ui-rounded, "Avenir Next", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     font-kerning: normal;
@@ -172,11 +169,11 @@
       box-shadow 150ms var(--bw-ease);
   }
 
-  .bw-button-primary {
-    background: var(--bw-primary-dark);
-    color: oklch(98% 0.01 118);
-    box-shadow: 0 10px 22px oklch(34% 0.12 151 / 0.2);
-  }
+	  .bw-button-primary {
+	    background: var(--bw-primary-dark);
+	    color: oklch(98% 0.01 118);
+	    box-shadow: 0 8px 18px oklch(27% 0.09 154 / 0.18);
+	  }
 
   .bw-button-primary:hover {
     background: var(--bw-primary);
@@ -256,7 +253,7 @@
     top: 0;
     z-index: 40;
     border-bottom: 1px solid var(--bw-border);
-    background: oklch(97.5% 0.016 118 / 0.94);
+    background: oklch(96.5% 0.022 128 / 0.94);
     backdrop-filter: blur(14px);
   }
 
@@ -342,32 +339,67 @@
   .bw-hero-showcase {
     position: relative;
     isolation: isolate;
-    padding: clamp(0.25rem, 2vw, 1rem);
+    overflow: hidden;
+    border: 1px solid oklch(49% 0.085 150);
+    border-radius: var(--bw-radius);
+    background:
+      linear-gradient(140deg, oklch(31% 0.09 153), oklch(21% 0.065 158)),
+      var(--bw-primary-dark);
+    padding: clamp(0.8rem, 2.5vw, 1.25rem);
+    box-shadow: var(--bw-shadow);
   }
 
   .bw-hero-showcase::before {
     position: absolute;
-    inset: 10% 0 8% 8%;
+    inset: 0;
     z-index: -1;
-    border: 1px solid var(--bw-border);
-    border-radius: var(--bw-radius);
     background:
-      linear-gradient(135deg, oklch(99% 0.008 118), oklch(93.5% 0.035 133)),
-      var(--bw-surface);
-    box-shadow: var(--bw-shadow);
+      linear-gradient(115deg, transparent 0 58%, oklch(46% 0.1 150 / 0.24) 58% 100%),
+      linear-gradient(180deg, oklch(100% 0.01 118 / 0.08), transparent 42%);
     content: "";
+  }
+
+  .bw-hero-showcase__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    .bw-hero-showcase__header {
+      flex-direction: row;
+      align-items: end;
+      justify-content: space-between;
+    }
+  }
+
+  .bw-hero-showcase__label {
+    color: var(--bw-accent);
+    font-size: 0.78rem;
+    font-weight: 900;
+    letter-spacing: 0.06em;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .bw-hero-showcase__note {
+    max-width: 20rem;
+    color: oklch(84% 0.035 126);
+    font-size: 0.9rem;
+    line-height: 1.35;
   }
 
   .bw-hero-placeholder {
     display: flex;
-    min-height: 14rem;
+    min-height: 11.5rem;
     flex-direction: column;
     justify-content: space-between;
-    border: 1px solid var(--bw-border);
+    border: 1px solid oklch(62% 0.065 150);
     border-radius: var(--bw-radius);
-    background: var(--bw-surface);
+    background: oklch(97.5% 0.018 116);
     padding: 1.15rem;
-    box-shadow: var(--bw-shadow-sm);
+    box-shadow: 0 1px 0 oklch(100% 0.01 118 / 0.36) inset;
     color: var(--bw-ink);
     text-decoration: none;
     transition:
@@ -390,23 +422,20 @@
     line-height: 1.2;
   }
 
-  @media (hover: hover) {
-    .bw-hero-placeholder:hover {
-      border-color: var(--bw-primary);
-      box-shadow: var(--bw-shadow);
-      transform: translateY(-2px);
-    }
+	  @media (hover: hover) {
+	    .bw-hero-placeholder:hover {
+	      border-color: var(--bw-accent);
+	      box-shadow: 0 10px 20px oklch(13% 0.05 156 / 0.16);
+	      transform: translateY(-2px);
+	    }
 
     .bw-hero-placeholder:hover .bw-hero-placeholder__action {
       color: var(--bw-ink);
     }
 
-    .bw-hero-placeholder.sm\:translate-y-6:hover {
-      transform: translateY(1.25rem);
-    }
-
-    .bw-hero-placeholder.sm\:-translate-y-6:hover {
-      transform: translateY(-1.75rem);
+    .bw-hero-placeholder:hover .bw-menu-icon {
+      background: var(--bw-accent);
+      color: var(--bw-ink);
     }
   }
 
@@ -415,7 +444,8 @@
     grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
     border: 1px solid var(--bw-border);
     border-radius: var(--bw-radius);
-    background: var(--bw-surface);
+    background: oklch(97.3% 0.016 106 / 0.86);
+    box-shadow: var(--bw-shadow-sm);
   }
 
   .bw-proof-strip > * {

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -1,3 +1,20 @@
+from django.template.loader import render_to_string
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Job
+
+
+class JobItemTemplateTests(TestCase):
+    def test_job_item_omits_empty_submitted_datetime(self):
+        job = Job.objects.create(
+            title="Django developer",
+            listing_url="https://example.com/jobs/django-developer",
+            company_name="Example Co",
+            approved=True,
+        )
+
+        html = render_to_string("components/job-item.html", {"job": job})
+
+        self.assertIn("Django developer", html)
+        self.assertNotIn("la-clock", html)
+        self.assertNotIn(" ago", html)

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -58,10 +58,16 @@ class JobDetailView(DetailView):
         description = job.title
 
         # Ensure the company_logo URL is absolute
-        if job.company_logo:
-            image_url = self.request.build_absolute_uri(job.company_logo.url)
-        else:
-            # Fallback to a default image if no company logo is available
+        company_logo_url = ""
+
+        try:
+            if job.company_logo:
+                company_logo_url = job.company_logo.url
+                image_url = self.request.build_absolute_uri(company_logo_url)
+            else:
+                # Fallback to a default image if no company logo is available
+                image_url = self.request.build_absolute_uri(static("vendors/images/logo.png"))
+        except ValueError:
             image_url = self.request.build_absolute_uri(static("vendors/images/logo.png"))
 
         og_image_url = (
@@ -75,6 +81,7 @@ class JobDetailView(DetailView):
             f"key=dQrmHqDSY5"
         )
         context["og_image"] = og_image_url
+        context["company_logo_url"] = company_logo_url
 
         return context
 

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -1,3 +1,48 @@
-from django.test import TestCase
+from datetime import timedelta
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from jobs.models import Job
+from pages.views import HomeView
+
+
+class HomeViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_home_jobs_only_include_recent_approved_jobs(self):
+        recent_job = Job.objects.create(
+            title="Recent Django role",
+            listing_url="https://example.com/jobs/recent",
+            company_name="Recent Co",
+            approved=True,
+            created_datetime=timezone.now() - timedelta(days=2),
+        )
+        old_job = Job.objects.create(
+            title="Old Django role",
+            listing_url="https://example.com/jobs/old",
+            company_name="Old Co",
+            approved=True,
+            created_datetime=timezone.now() - timedelta(days=61),
+        )
+        unapproved_job = Job.objects.create(
+            title="Unapproved Django role",
+            listing_url="https://example.com/jobs/unapproved",
+            company_name="Draft Co",
+            approved=False,
+            created_datetime=timezone.now(),
+        )
+
+        request = self.factory.get("/")
+        view = HomeView()
+        view.setup(request)
+
+        with patch("pages.views.static", return_value="/static/vendors/images/logo.png"):
+            context = view.get_context_data()
+
+        jobs = list(context["jobs"])
+        self.assertIn(recent_job, jobs)
+        self.assertNotIn(old_job, jobs)
+        self.assertNotIn(unapproved_job, jobs)

--- a/pages/views.py
+++ b/pages/views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from allauth.account.models import EmailAddress
 from django.conf import settings
@@ -9,6 +9,7 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.http import HttpResponseRedirect
 from django.templatetags.static import static  # Add this import
 from django.urls import reverse, reverse_lazy
+from django.utils import timezone
 from django.views import View
 from django.views.generic import CreateView, RedirectView, TemplateView, UpdateView
 from django_q.tasks import async_task
@@ -38,7 +39,10 @@ class HomeView(TemplateView):
         ]
         context["guides"] = Post.objects.filter(type="TUTORIAL")[:4]
         context["podcast_episodes"] = Episode.objects.all()[:3]
-        context["jobs"] = Job.objects.filter(approved=True).order_by("-created_datetime")[:6]
+        filter_date = timezone.now() - timedelta(days=60)
+        context["jobs"] = Job.objects.filter(approved=True, created_datetime__gte=filter_date).order_by(
+            "-created_datetime"
+        )[:6]
 
         title = "Built with Django"
         description = "Learn to bring your project and business ideas to life with Django. Get inspired by others."

--- a/projects/urls.py
+++ b/projects/urls.py
@@ -5,11 +5,11 @@ from .views import InactiveProjectListView, ProjectCreateView, ProjectDetailView
 urlpatterns = [
     path("", ProjectListView.as_view(), name="projects"),
     path("inactive", InactiveProjectListView.as_view(), name="inactive-projects"),
+    path("new/", ProjectCreateView.as_view(), name="submit_project"),
     path("<slug:slug>", ProjectDetailView.as_view(), name="project"),
     path(
         "<slug:slug>/update",
         ProjectUpdateView.as_view(),
         name="project_update",
     ),
-    path("new/", ProjectCreateView.as_view(), name="submit_project"),
 ]

--- a/projects/views.py
+++ b/projects/views.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.db.models import Count, Q
+from django.templatetags.static import static
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from django_filters.views import FilterView
@@ -66,6 +67,13 @@ class ProjectDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["newsletter_form"] = NewsletterSignupForm
+        context["project_screenshot_url"] = self.request.build_absolute_uri(static("vendors/images/logo.png"))
+
+        try:
+            if self.object.homepage_screenshot:
+                context["project_screenshot_url"] = self.request.build_absolute_uri(self.object.homepage_screenshot.url)
+        except ValueError:
+            pass
 
         return context
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -257,11 +257,137 @@
           </div>
         </div>
       </div>
-      <div class="bw-container border-t border-[oklch(35%_0.035_156)] py-4">
-        <div class="scale-75 origin-left">
-          <webring-css site="https://builtwithdjango.com"></webring-css>
-          <script src="https://djangowebring.com/static/webring.js"></script>
+      <div class="bw-webring-shell">
+        <div class="bw-webring-panel">
+          <div class="bw-webring-copy">
+            <p class="bw-webring-label">Community ring</p>
+            <h2>A small Django neighborhood</h2>
+            <p>Built with Django is part of a small loop of independent Django sites. Follow the ring to find another corner of the community.</p>
+          </div>
+          <div class="bw-webring-widget">
+            <webring-css site="https://builtwithdjango.com"></webring-css>
+          </div>
         </div>
+        <script src="https://djangowebring.com/static/webring.js" defer></script>
+        <script>
+          function restyleDjangoWebring() {
+            const host = document.querySelector('.bw-webring-widget webring-css');
+            if (!host) return;
+
+            const styleId = 'builtwithdjango-webring-restyle';
+            const applyStyle = () => {
+              if (!host.shadowRoot) return false;
+              if (host.shadowRoot.getElementById(styleId)) return true;
+
+              const style = document.createElement('style');
+              style.id = styleId;
+              style.textContent = `
+                :host {
+                  display: block;
+                  width: 100%;
+                }
+
+                .django-webring {
+                  display: block !important;
+                  border: 0 !important;
+                  border-radius: 0 !important;
+                  background: transparent !important;
+                  box-shadow: none !important;
+                  padding: 0 !important;
+                  color: oklch(91% 0.025 126) !important;
+                  font-family: inherit !important;
+                  text-align: left !important;
+                }
+
+                .django-webring__icon {
+                  display: none !important;
+                }
+
+                .django-webring__content {
+                  display: grid !important;
+                  gap: 0.8rem !important;
+                }
+
+                .django-webring__content h1 {
+                  margin: 0 !important;
+                  color: oklch(96% 0.025 126) !important;
+                  font-size: clamp(1.1rem, 3vw, 1.45rem) !important;
+                  font-weight: 900 !important;
+                  line-height: 1.05 !important;
+                }
+
+                .django-webring__content h2 {
+                  margin: 0 !important;
+                  color: oklch(78% 0.12 92) !important;
+                  font-size: 0.95rem !important;
+                  font-weight: 850 !important;
+                  line-height: 1.35 !important;
+                }
+
+                .django-webring__content p {
+                  margin: 0 !important;
+                  color: oklch(78% 0.03 126) !important;
+                  font-size: 0.92rem !important;
+                  line-height: 1.55 !important;
+                }
+
+                .django-webring__content a {
+                  display: inline-flex !important;
+                  min-height: 2.45rem !important;
+                  align-items: center !important;
+                  justify-content: center !important;
+                  margin: 0.25rem 0.35rem 0 0 !important;
+                  border: 1px solid oklch(50% 0.06 150) !important;
+                  border-radius: 8px !important;
+                  background: oklch(18% 0.035 151) !important;
+                  color: oklch(94% 0.025 126) !important;
+                  padding: 0.58rem 0.8rem !important;
+                  font-size: 0.88rem !important;
+                  font-weight: 850 !important;
+                  line-height: 1 !important;
+                  text-decoration: none !important;
+                  transition:
+                    background-color 160ms cubic-bezier(0.22, 1, 0.36, 1),
+                    border-color 160ms cubic-bezier(0.22, 1, 0.36, 1),
+                    color 160ms cubic-bezier(0.22, 1, 0.36, 1),
+                    transform 160ms cubic-bezier(0.22, 1, 0.36, 1) !important;
+                }
+
+                .django-webring__content a:hover,
+                .django-webring__content a:focus-visible {
+                  border-color: oklch(79% 0.16 92) !important;
+                  background: oklch(78% 0.17 92) !important;
+                  color: oklch(16% 0.04 151) !important;
+                  transform: translateY(-1px) !important;
+                }
+
+                @media (max-width: 600px) {
+                  .django-webring__content {
+                    gap: 0.7rem !important;
+                  }
+
+                  .django-webring__content a {
+                    width: 100% !important;
+                    margin-right: 0 !important;
+                  }
+                }
+              `;
+              host.shadowRoot.appendChild(style);
+              return true;
+            };
+
+            let attempts = 0;
+            const interval = window.setInterval(() => {
+              attempts += 1;
+              if (applyStyle() || attempts > 40) {
+                window.clearInterval(interval);
+              }
+            }, 100);
+          }
+
+          document.addEventListener('DOMContentLoaded', restyleDjangoWebring);
+          document.addEventListener('turbo:load', restyleDjangoWebring);
+        </script>
       </div>
     </footer>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,526 +1,292 @@
 {% load webpack_loader static %}
-{% load cloudinary %}
 
+<!doctype html>
 <html lang="en">
-    <head>
-        <!-- Required meta tags -->
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <!-- Other meta stuff -->
-        <link rel="apple-touch-icon" href="{% static 'vendors/favicon/logo.png' %}" />
-        <link rel="apple-touch-icon" href="{% static 'vendors/favicon/logo.png' %}" />
-        <link rel="icon" type="image/png" sizes="16x16 32x32 500x500" href="{% static 'vendors/favicon/logo.png' %}"/>
-        <meta property="og:type" content="website" />
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link rel="apple-touch-icon" href="{% static 'vendors/favicon/logo.png' %}" />
+    <link rel="icon" type="image/png" sizes="16x16 32x32 500x500" href="{% static 'vendors/favicon/logo.png' %}" />
+    <meta property="og:type" content="website" />
 
-        {% block meta %}
-            <title>Built with Django</title>
-            <meta name="description" content="Collection of cool projects people built with Django"/>
-            <link rel="canonical" href="https://{{ request.get_host }}" />
-            <meta property="og:title" content="Built with Django" />
-            <meta property="og:url" content="https://{{ request.get_host }}" />
-            <meta property="og:description" content="Collection of cool projects people built with Django"/>
-            <meta property="og:image" content="{{ og_image }}" />
-            <meta name="twitter:card" content="summary_large_image" />
-            <meta name="twitter:creator" content="@rasulkireev" />
-            <meta name="twitter:site" content="@rasulkireev" />
-            <meta name="twitter:title" content="Built with Django" />
-            <meta name="twitter:description" content="Collection of cool projects people built with Django"/>
-            <meta name="twitter:image" content="{{ og_image }}"/>
-        {% endblock meta %}
+    {% block meta %}
+      <title>Built with Django</title>
+      <meta name="description" content="Collection of cool projects people built with Django" />
+      <link rel="canonical" href="https://{{ request.get_host }}" />
+      <meta property="og:title" content="Built with Django" />
+      <meta property="og:url" content="https://{{ request.get_host }}" />
+      <meta property="og:description" content="Collection of cool projects people built with Django" />
+      <meta property="og:image" content="{{ og_image }}" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:creator" content="@rasulkireev" />
+      <meta name="twitter:site" content="@builtwithdjango" />
+      <meta name="twitter:title" content="Built with Django" />
+      <meta name="twitter:description" content="Collection of cool projects people built with Django" />
+      <meta name="twitter:image" content="{{ og_image }}" />
+    {% endblock meta %}
 
-        <!-- CSS -->
-        <!-- CSS refresh solution from https://stackoverflow.com/a/56987021/6020165 -->
-        <link rel="stylesheet"
-              href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css"/>
-        <link rel="stylesheet"
-              href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css" />
-        {% stylesheet_pack 'hotwire' attrs='data-turbo-track="reload"' %}
+    <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css" />
+    {% stylesheet_pack 'hotwire' attrs='data-turbo-track="reload"' %}
 
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
-        <script defer data-domain="builtwithdjango.com" src="https://plausible-v2.cr.lvtd.dev/js/script.js"></script>
-        {% javascript_pack 'hotwire' attrs='data-turbo-track="reload" defer' %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
+    <script defer data-domain="builtwithdjango.com" src="https://plausible-v2.cr.lvtd.dev/js/script.js"></script>
+    {% javascript_pack 'hotwire' attrs='data-turbo-track="reload" defer' %}
 
-        {% block extra_top_js %}
-        {% endblock extra_top_js %}
+    {% block extra_top_js %}
+    {% endblock extra_top_js %}
 
-        {% block style %}
-        {% endblock style %}
+    {% block style %}
+    {% endblock style %}
 
-        <script>
-          !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-          posthog.init('phc_Xvm3S1MGcMQXMHo2VJZabDhNJwmwbyhLedddpIU83Mo',{api_host:'https://app.posthog.com'})
-        </script>
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_Xvm3S1MGcMQXMHo2VJZabDhNJwmwbyhLedddpIU83Mo',{api_host:'https://app.posthog.com'})
+    </script>
+  </head>
 
-    </head>
+  <body class="antialiased">
+    <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-3 focus:left-3 focus:z-50 focus:rounded-md focus:bg-yellow-300 focus:px-4 focus:py-2 focus:font-bold focus:text-gray-900">
+      Skip to content
+    </a>
 
-    <body>
-        {% block default_messages %}
-          {% include "components/messages.html" with messages=messages %}
-        {% endblock default_messages %}
-        <nav x-data="{ isOn: false }">
-            <div class="px-4 mx-auto max-w-6xl sm:px-6 lg:px-8">
-                <div class="flex relative justify-between items-center h-24">
-                    <div class="flex absolute inset-y-0 left-0 items-center sm:hidden">
-                        <!-- Mobile menu button-->
-                        <button type="button"
-                                @click="isOn = !isOn"
-                                class="inline-flex justify-center items-center p-2 text-gray-400 rounded-md hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
-                                aria-controls="mobile-menu"
-                                aria-expanded="false">
-                            <span class="sr-only">Open main menu</span>
-                            <svg :class="{'hidden': isOn, 'block': !isOn }"
-                                 class="w-6 h-6"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 fill="none"
-                                 viewBox="0 0 24 24"
-                                 stroke="currentColor"
-                                 aria-hidden="true">
-                                <path stroke-linecap="round"
-                                      stroke-linejoin="round"
-                                      stroke-width="2"
-                                      d="M4 6h16M4 12h16M4 18h16"/>
-                            </svg>
-                            <svg :class="{'block': isOn, 'hidden': !isOn }"
-                                 class="w-6 h-6"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 fill="none"
-                                 viewBox="0 0 24 24"
-                                 stroke="currentColor"
-                                 aria-hidden="true">
-                                <path stroke-linecap="round"
-                                      stroke-linejoin="round"
-                                      stroke-width="2"
-                                      d="M6 18L18 6M6 6l12 12"/>
-                            </svg>
-                        </button>
-                    </div>
-                    <div class="flex flex-1 justify-center items-center sm:items-stretch sm:justify-start">
-                        <div class="flex flex-shrink-0 items-center">
-                            <a href="{% url 'home' %}">
-                              <img class="block w-auto h-10 lg:hidden"
-                                   src="{% static 'vendors/images/logo.png' %}"
-                                   alt="Built with Django Logo"
-                              />
-                            </a>
-                            <a href="{% url 'home' %}">
-                              <img class="hidden w-auto h-12 lg:block"
-                                   src="{% static 'vendors/images/logo.png' %}"
-                                   alt="Built with Django Logo" />
-                            </a>
-                        </div>
-                        <div class="hidden sm:block sm:ml-6">
-                            <div class="flex space-x-4">
-                              <div data-controller="dropdown" class="relative">
-                                <button
-                                  type="button"
-                                  data-action="dropdown#toggle click@window->dropdown#hide"
-                                  class="inline-flex items-center px-3 py-2 text-lg font-medium text-gray-600 bg-white rounded-md group hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-                                  aria-expanded="false"
-                                >
-                                  <span>Learn</span>
-                                  <svg class="ml-2 w-5 h-5 text-gray-400 group-hover:text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                  </svg>
-                                </button>
+    {% block default_messages %}
+      {% include "components/messages.html" with messages=messages %}
+    {% endblock default_messages %}
 
-                                <div data-dropdown-target="menu"
-                                  data-transition-enter-active="transition ease-out duration-200"
-                                  data-transition-enter-from="opacity-0 translate-y-1"
-                                  data-transition-enter-to="opacity-100 translate-y-0"
-                                  data-transition-leave-active="transition ease-in duration-150"
-                                  data-transition-leave-from="opacity-100 translate-y-0"
-                                  data-transition-leave-to="opacity-0 translate-y-1"
-                                  class="hidden absolute left-1/2 z-10 px-2 mt-3 w-screen max-w-xs transform -translate-x-1/2 sm:px-0"
-                                >
-                                  <div class="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 shadow-lg">
-                                    <div class="grid relative gap-6 px-5 py-6 bg-white sm:gap-8 sm:p-8">
-                                      <a href="{% url 'blog' %}" class="block p-3 -m-3 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-brain"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Guides</p>
-                                            <p class="mt-1 text-sm text-gray-500">Tutorials that will help you on your dev journey.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                      <a href="{% url 'projects' %}" class="block p-3 -m-3 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-brush"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Projects</p>
-                                            <p class="mt-1 text-sm text-gray-500">Get inspired by what others are building with Django.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-
-                              <div data-controller="dropdown" class="relative">
-                                <button
-                                  type="button"
-                                  data-action="dropdown#toggle click@window->dropdown#hide"
-                                  class="inline-flex items-center px-3 py-2 text-lg font-medium text-gray-600 bg-white rounded-md group hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-                                  aria-expanded="false"
-                                >
-                                  <span>Tools</span>
-                                  <svg class="ml-2 w-5 h-5 text-gray-400 group-hover:text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                  </svg>
-                                </button>
-
-                                <div data-dropdown-target="menu"
-                                  data-transition-enter-active="transition ease-out duration-200"
-                                  data-transition-enter-from="opacity-0 translate-y-1"
-                                  data-transition-enter-to="opacity-100 translate-y-0"
-                                  data-transition-leave-active="transition ease-in duration-150"
-                                  data-transition-leave-from="opacity-100 translate-y-0"
-                                  data-transition-leave-to="opacity-0 translate-y-1"
-                                  class="hidden absolute left-1/2 z-10 px-2 mt-3 w-screen max-w-xs transform -translate-x-1/2 sm:px-0"
-                                >
-                                  <div class="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 shadow-lg">
-                                    <div class="grid relative gap-6 px-5 py-6 bg-white sm:gap-8 sm:p-8">
-                                      <a href="{% url 'generate_django_secret_page' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-key"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Generate Django Secret</p>
-                                            <p class="mt-1 text-sm text-gray-500">Quickest way to generate a Django Secret for your project!</p>
-                                          </div>
-                                        </div>
-                                      </a>
-                                      <a href="{% url 'format_html_view' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-shower"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Django HTML Formatter</p>
-                                            <p class="mt-1 text-sm text-gray-500">Make your Django templates pretty in seconds.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-
-                              <div data-controller="dropdown" class="relative">
-                                <button
-                                  type="button"
-                                  data-action="dropdown#toggle click@window->dropdown#hide"
-                                  class="inline-flex items-center px-3 py-2 text-lg font-medium text-gray-600 bg-white rounded-md group hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-                                  aria-expanded="false"
-                                >
-                                  <span>More</span>
-                                  <svg class="ml-2 w-5 h-5 text-gray-400 group-hover:text-gray-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                  </svg>
-                                </button>
-
-                                <div data-dropdown-target="menu"
-                                  data-transition-enter-active="transition ease-out duration-200"
-                                  data-transition-enter-from="opacity-0 translate-y-1"
-                                  data-transition-enter-to="opacity-100 translate-y-0"
-                                  data-transition-leave-active="transition ease-in duration-150"
-                                  data-transition-leave-from="opacity-100 translate-y-0"
-                                  data-transition-leave-to="opacity-0 translate-y-1"
-                                  class="hidden absolute left-1/2 z-10 px-2 mt-3 w-screen max-w-xs transform -translate-x-1/2 sm:px-0"
-                                >
-                                  <div class="overflow-hidden rounded-lg ring-1 ring-black ring-opacity-5 shadow-lg">
-                                    <div class="grid relative gap-6 px-5 py-6 bg-white sm:gap-8 sm:p-8">
-                                      <a href="{% url 'articles' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-newspaper"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Articles</p>
-                                            <p class="mt-1 text-sm text-gray-500">Read all our articles, updates, and content.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                      <a href="{% url 'jobs' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-briefcase"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Django Job Board</p>
-                                            <p class="mt-1 text-sm text-gray-500">Find the Django job of your dreams!</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                      <a href="{% url 'podcast_episodes' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-microphone-alt"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Built with Django Podcast</p>
-                                            <p class="mt-1 text-sm text-gray-500">Listen to the best Django devs out there.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                      <a href="{% url 'developers' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-running"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Django Developers</p>
-                                            <p class="mt-1 text-sm text-gray-500">Hire the best Django Developers this world has to offer.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                      <a href="{% url 'advertize' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-bullhorn"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Advertize</p>
-                                            <p class="mt-1 text-sm text-gray-500">Let the Django Community know about your project.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                      <a href="{% url 'support' %}" class="block p-3 -m-4 rounded-md hover:bg-gray-50">
-                                        <div class="flex flex-row space-x-3">
-                                          <div class="flex flex-shrink-0 justify-center items-center w-10 h-10 text-2xl text-white bg-green-500 rounded-md sm:h-12 sm:w-12">
-                                            <i class="las la-life-ring"></i>
-                                          </div>
-                                          <div>
-                                            <p class="text-base font-medium text-gray-900">Support</p>
-                                            <p class="mt-1 text-sm text-gray-500">Here are some ways you can support Built with Django.</p>
-                                          </div>
-                                        </div>
-                                      </a>
-
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="flex absolute inset-y-0 right-0 items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
-                        {% if user.is_authenticated %}
-                            <!-- Profile dropdown -->
-                            <div data-controller="dropdown" class="relative ml-3">
-                                <div>
-                                    <button type="button"
-                                            data-action="dropdown#toggle click@window->dropdown#hide"
-                                            class="flex text-sm bg-gray-800 rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white"
-                                            id="user-menu-button"
-                                            aria-expanded="false"
-                                            aria-haspopup="true">
-                                        <span class="sr-only">Open user menu</span>
-                                        {% include "components/profile-image.html" %}
-                                    </button>
-                                </div>
-                                <div data-dropdown-target="menu"
-                                     data-transition-enter-active="transition ease-out duration-100"
-                                     data-transition-enter-from="transform opacity-0 scale-95"
-                                     data-transition-enter-to="transform opacity-100 scale-100"
-                                     data-transition-leave-active="transition ease-in duration-75"
-                                     data-transition-leave-from="transform opacity-100 scale-100"
-                                     data-transition-leave-to="transform opacity-0 scale-95"
-                                     class="hidden absolute right-0 py-1 mt-2 w-48 bg-white rounded-md ring-1 ring-black ring-opacity-5 shadow-lg origin-top-right focus:outline-none"
-                                     role="menu"
-                                     aria-orientation="vertical"
-                                     aria-labelledby="user-menu-button"
-                                     tabindex="-1">
-                                    <!-- Active: "bg-gray-100", Not Active: "" -->
-                                    <p class="block px-4 py-2 text-sm text-gray-700"
-                                       role="menuitem"
-                                       data-action="dropdown#toggle"
-                                       tabindex="-1"
-                                       id="user-menu-item-0">{{ user.username }}</p>
-                                    <!-- Active: "bg-gray-100", Not Active: "" -->
-                                    <a href="{% url 'update-profile' %}"
-                                       class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-300"
-                                       role="menuitem"
-                                       data-action="dropdown#toggle"
-                                       tabindex="-1"
-                                       id="user-menu-item-0">Update Profile</a>
-                                    <!-- Admin Panel Link - Only visible to superusers -->
-                                    {% if user.is_superuser %}
-                                    <a href="{% url 'admin-panel' %}"
-                                       class="block px-4 py-2 text-sm font-semibold text-green-700 bg-green-50 border-t border-b border-green-200 hover:bg-green-100"
-                                       role="menuitem"
-                                       data-action="dropdown#toggle"
-                                       tabindex="-1"
-                                       id="user-menu-item-admin">
-                                       <span class="flex items-center">
-                                           <svg class="mr-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
-                                           </svg>
-                                           Admin Panel
-                                       </span>
-                                    </a>
-                                    {% endif %}
-                                    <!-- <a href="#" class="block px-4 py-2 text-sm text-gray-700" role="menuitem" tabindex="-1" id="user-menu-item-1">Settings</a> -->
-                                    <a href="{% url 'account_logout' %}"
-                                       class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-300"
-                                       role="menuitem"
-                                       data-action="dropdown#toggle"
-                                       tabindex="-1"
-                                       id="user-menu-item-2">Sign out</a>
-                                </div>
-                            </div>
-                        {% else %}
-                            <div class="hidden flex-row flex-shrink-0 space-x-2 md:flex">
-                                <a href="{% url 'account_signup' %}"
-                                   class="inline-flex relative items-center px-3 py-2 text-lg font-medium text-white bg-green-700 rounded-md border border-transparent border-solid shadow-sm hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-green-500">
-                                    <span>Sign up</span>
-                                </a>
-                                <a href="{% url 'account_login' %}"
-                                class="inline-flex relative items-center px-3 py-2 text-lg font-medium text-green-600 bg-white rounded-md border border-gray-200 border-solid shadow hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-gray-200">
-                                 <span>Login</span>
-                             </a>
-                            </div>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-            <div :class="{'block': isOn, 'hidden': !isOn }" class="sm:hidden" id="mobile-menu">
-                <div class="px-2 pt-2 pb-3 space-y-1">
-                    <a href="{% url 'projects' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Projects">Projects</a>
-                    <a href="{% url 'jobs' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Jobs">Jobs</a>
-                    <a href="{% url 'blog' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Blog">Blog</a>
-                    <a href="{% url 'podcast_episodes' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Podcast">Podcast</a>
-                    <a href="{% url 'developers' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Developers">Developers</a>
-                    <a href="{% url 'generate_django_secret_page' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Developers">Generate Django Secret Key</a>
-                    <a href="{% url 'format_html_view' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Developers">Django HTML Formatter</a>
-                    <a href="{% url 'advertize' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Developers">Advertize your Project</a>
-                    <a href="{% url 'support' %}"
-                       class="block px-3 py-2 text-base font-medium text-gray-700 rounded-md hover:bg-gray-700 hover:text-white"
-                       key="Developers">Support Built with Django</a>
-
-                    <!-- Admin Panel Link for Mobile - Only visible to superusers -->
-                    {% if user.is_authenticated and user.is_superuser %}
-                    <a href="{% url 'admin-panel' %}"
-                       class="block px-3 py-2 text-base font-semibold text-green-700 bg-green-50 rounded-md border-2 border-green-200 hover:bg-green-100"
-                       key="AdminPanel">
-                       <span class="flex justify-center items-center">
-                           <svg class="mr-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
-                           </svg>
-                           Admin Panel
-                       </span>
-                    </a>
-                    {% endif %}
-
-                    {% if not user.is_authenticated %}
-                      <a href="{% url 'account_login' %}"
-                       class="block px-3 py-2 text-base font-medium text-center text-gray-700 rounded-md border-2 border-gray-300 hover:bg-gray-700 hover:text-white"
-                       key="Login">Login</a>
-                    <a href="{% url 'account_signup' %}"
-                       class="block px-3 py-2 text-base font-medium text-center text-white bg-green-700 rounded-md hover:bg-green-800"
-                       key="Signup">Sign Up</a>
-                    {% endif %}
-
-                </div>
-            </div>
-        </nav>
-
-        <div class="px-2 mx-auto max-w-6xl sm:px-6 lg:px-8">
-            {% block content %}{% endblock content %}
-        </div>
-
-        <footer class="bg-white">
-          <div class="px-6 py-12 mx-auto max-w-7xl md:py-0 md:flex md:items-center md:justify-between lg:px-8">
-            <div class="mt-8 md:mt-0">
-              <p class="text-xs leading-5 text-center text-gray-500">
-                &copy; 2025 <a href="https://lvtd.dev">LVTD, LLC</a>.
-              </p>
-            </div>
-
-            <div class="scale-50">
-              <webring-css site="https://builtwithdjango.com"></webring-css>
-              <script src="https://djangowebring.com/static/webring.js"></script>
-            </div>
-
-            <div class="flex justify-center space-x-6">
-              <a href="https://statushen.com/builtwithdjango" class="text-gray-400 hover:text-gray-500">
-                Status
-              </a>
-              <a href="https://x.com/rasulkireev" class="text-gray-400 hover:text-gray-500">
-                <span class="sr-only">X</span>
-                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M13.6823 10.6218L20.2391 3H18.6854L12.9921 9.61788L8.44486 3H3.2002L10.0765 13.0074L3.2002 21H4.75404L10.7663 14.0113L15.5685 21H20.8131L13.6819 10.6218H13.6823ZM11.5541 13.0956L10.8574 12.0991L5.31391 4.16971H7.70053L12.1742 10.5689L12.8709 11.5655L18.6861 19.8835H16.2995L11.5541 13.096V13.0956Z" />
-                </svg>
-              </a>
-              <a href="https://github.com/builtwithdjango" class="text-gray-400 hover:text-gray-500">
-                <span class="sr-only">GitHub</span>
-                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd" />
-                </svg>
-              </a>
-            </div>
-          </div>
-        </footer>
-
-        <a class="fixed bottom-0 left-0 z-10 px-2 py-1 font-semibold text-gray-900 no-underline bg-gray-200 rounded-tr border-t border-l border-white border-solid"
-           href="https://rasulkireev.com"
-           target="_blank">
-            <!-- <img class="inline w-4 align-middle rounded" src="https://github.com/account" alt="Rasul Kireev"/> -->
-            <p class="inline m-0 ml-1 text-sm font-normal align-middle">by Rasul</p>
+    <header class="bw-site-header" x-data="{ isOn: false }">
+      <nav class="bw-container flex min-h-[4.5rem] items-center justify-between gap-4" aria-label="Primary navigation">
+        <a href="{% url 'home' %}" class="bw-brand">
+          <img src="{% static 'vendors/images/logo.png' %}" alt="Built with Django Logo" />
+          <span class="hidden text-lg sm:inline">Built with Django</span>
         </a>
 
-        {% include "components/bottom-right-corner-ad.html" %}
+        <div class="hidden items-center gap-1 lg:flex">
+          <a href="{% url 'projects' %}" class="bw-nav-link">Projects</a>
+          <a href="{% url 'blog' %}" class="bw-nav-link">Guides</a>
+          <a href="{% url 'jobs' %}" class="bw-nav-link">Jobs</a>
+          <a href="{% url 'developers' %}" class="bw-nav-link">Developers</a>
+          <div data-controller="dropdown" class="relative">
+            <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" class="bw-nav-link" aria-expanded="false">
+              Resources
+              <i class="las la-angle-down ml-1 text-sm" aria-hidden="true"></i>
+            </button>
+            <div data-dropdown-target="menu"
+                 data-transition-enter-active="transition ease-out duration-200"
+                 data-transition-enter-from="opacity-0 translate-y-1"
+                 data-transition-enter-to="opacity-100 translate-y-0"
+                 data-transition-leave-active="transition ease-in duration-150"
+                 data-transition-leave-from="opacity-100 translate-y-0"
+                 data-transition-leave-to="opacity-0 translate-y-1"
+                 class="hidden absolute left-1/2 z-20 mt-3 w-80 -translate-x-1/2">
+              <div class="bw-menu-panel p-2">
+                <a href="{% url 'podcast_episodes' %}" class="bw-menu-item">
+                  <span class="bw-menu-icon"><i class="las la-microphone-alt" aria-hidden="true"></i></span>
+                  <span>
+                    <span class="block font-bold">Podcast</span>
+                    <span class="block text-sm bw-muted">Conversations with Django builders.</span>
+                  </span>
+                </a>
+                <a href="{% url 'makers' %}" class="bw-menu-item">
+                  <span class="bw-menu-icon"><i class="las la-users" aria-hidden="true"></i></span>
+                  <span>
+                    <span class="block font-bold">Makers</span>
+                    <span class="block text-sm bw-muted">People shipping with Django.</span>
+                  </span>
+                </a>
+                <a href="{% url 'advertize' %}" class="bw-menu-item">
+                  <span class="bw-menu-icon"><i class="las la-bullhorn" aria-hidden="true"></i></span>
+                  <span>
+                    <span class="block font-bold">Advertise</span>
+                    <span class="block text-sm bw-muted">Reach the Django community.</span>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+          <div data-controller="dropdown" class="relative">
+            <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" class="bw-nav-link" aria-expanded="false">
+              Tools
+              <i class="las la-angle-down ml-1 text-sm" aria-hidden="true"></i>
+            </button>
+            <div data-dropdown-target="menu"
+                 data-transition-enter-active="transition ease-out duration-200"
+                 data-transition-enter-from="opacity-0 translate-y-1"
+                 data-transition-enter-to="opacity-100 translate-y-0"
+                 data-transition-leave-active="transition ease-in duration-150"
+                 data-transition-leave-from="opacity-100 translate-y-0"
+                 data-transition-leave-to="opacity-0 translate-y-1"
+                 class="hidden absolute left-1/2 z-20 mt-3 w-80 -translate-x-1/2">
+              <div class="bw-menu-panel p-2">
+                <a href="{% url 'generate_django_secret_page' %}" class="bw-menu-item">
+                  <span class="bw-menu-icon"><i class="las la-key" aria-hidden="true"></i></span>
+                  <span>
+                    <span class="block font-bold">Secret key generator</span>
+                    <span class="block text-sm bw-muted">Generate a Django secret key quickly.</span>
+                  </span>
+                </a>
+                <a href="{% url 'format_html_view' %}" class="bw-menu-item">
+                  <span class="bw-menu-icon"><i class="las la-code" aria-hidden="true"></i></span>
+                  <span>
+                    <span class="block font-bold">Template formatter</span>
+                    <span class="block text-sm bw-muted">Clean up Django HTML templates.</span>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
 
-        {% block schema %}
-            <script type="application/ld+json">
-            {
-              "@context": "https://schema.org",
-              "@type": "WebSite",
-              "name": "Projects Built with Django",
-              "description": "Collection of cool projects people built with Django",
-              "thumbnailUrl": "https{{ og_image }}",
-              "url": "https://{{ request.get_host }}",
-              "author": {
-                "@type": "Person",
-                "givenName": "Rasul",
-                "familyName": "Kireev",
-                "url": "https://rasulkireev.com/"
-              }
-            }
-            </script>
-        {% endblock schema %}
+        <div class="hidden items-center gap-2 md:flex">
+          <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent">Submit project</a>
+          {% if user.is_authenticated %}
+            <div data-controller="dropdown" class="relative">
+              <button type="button"
+                      data-action="dropdown#toggle click@window->dropdown#hide"
+                      class="inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)]"
+                      aria-expanded="false"
+                      aria-haspopup="true">
+                <span class="sr-only">Open user menu</span>
+                {% include "components/profile-image.html" %}
+              </button>
+              <div data-dropdown-target="menu"
+                   data-transition-enter-active="transition ease-out duration-100"
+                   data-transition-enter-from="transform opacity-0 scale-95"
+                   data-transition-enter-to="transform opacity-100 scale-100"
+                   data-transition-leave-active="transition ease-in duration-75"
+                   data-transition-leave-from="transform opacity-100 scale-100"
+                   data-transition-leave-to="transform opacity-0 scale-95"
+                   class="bw-menu-panel hidden absolute right-0 z-20 mt-3 w-56 p-2"
+                   role="menu">
+                <p class="px-3 py-2 text-sm font-bold bw-muted">{{ user.username }}</p>
+                <a href="{% url 'update-profile' %}" class="bw-menu-item" role="menuitem">Update profile</a>
+                {% if user.is_superuser %}
+                  <a href="{% url 'admin-panel' %}" class="bw-menu-item" role="menuitem">Admin panel</a>
+                {% endif %}
+                <a href="{% url 'account_logout' %}" class="bw-menu-item" role="menuitem">Sign out</a>
+              </div>
+            </div>
+          {% else %}
+            <a href="{% url 'account_login' %}" class="bw-button bw-button-secondary">Sign in</a>
+          {% endif %}
+        </div>
 
-        {% block extra_bottom_js %}
-        {% endblock extra_bottom_js %}
-    </body>
+        <button type="button"
+                @click="isOn = !isOn"
+                :aria-expanded="isOn.toString()"
+                class="bw-icon-button md:hidden"
+                aria-controls="mobile-menu">
+          <span class="sr-only">Open main menu</span>
+          <i :class="{'hidden': isOn, 'block': !isOn }" class="las la-bars text-2xl" aria-hidden="true"></i>
+          <i :class="{'block': isOn, 'hidden': !isOn }" class="las la-times text-2xl" aria-hidden="true"></i>
+        </button>
+      </nav>
+
+      <div :class="{'block': isOn, 'hidden': !isOn }" class="bw-mobile-menu hidden md:hidden" id="mobile-menu">
+        <div class="bw-container py-3">
+          <div class="grid gap-5">
+            <div>
+              <p class="mb-2 text-xs font-black uppercase tracking-wider bw-muted">Browse</p>
+              <a href="{% url 'projects' %}" class="bw-mobile-link">Projects <i class="las la-arrow-right" aria-hidden="true"></i></a>
+              <a href="{% url 'blog' %}" class="bw-mobile-link">Guides <i class="las la-arrow-right" aria-hidden="true"></i></a>
+              <a href="{% url 'jobs' %}" class="bw-mobile-link">Jobs <i class="las la-arrow-right" aria-hidden="true"></i></a>
+              <a href="{% url 'developers' %}" class="bw-mobile-link">Developers <i class="las la-arrow-right" aria-hidden="true"></i></a>
+            </div>
+            <div>
+              <p class="mb-2 text-xs font-black uppercase tracking-wider bw-muted">Tools and community</p>
+              <a href="{% url 'generate_django_secret_page' %}" class="bw-mobile-link">Secret key generator <i class="las la-arrow-right" aria-hidden="true"></i></a>
+              <a href="{% url 'format_html_view' %}" class="bw-mobile-link">Template formatter <i class="las la-arrow-right" aria-hidden="true"></i></a>
+              <a href="{% url 'podcast_episodes' %}" class="bw-mobile-link">Podcast <i class="las la-arrow-right" aria-hidden="true"></i></a>
+              <a href="{% url 'advertize' %}" class="bw-mobile-link">Advertise <i class="las la-arrow-right" aria-hidden="true"></i></a>
+            </div>
+            <div class="grid grid-cols-1 gap-2 pb-2 sm:grid-cols-2">
+              <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent">Submit project</a>
+              {% if user.is_authenticated %}
+                <a href="{% url 'update-profile' %}" class="bw-button bw-button-secondary">Your profile</a>
+                {% if user.is_superuser %}
+                  <a href="{% url 'admin-panel' %}" class="bw-button bw-button-secondary">Admin panel</a>
+                {% endif %}
+              {% else %}
+                <a href="{% url 'account_login' %}" class="bw-button bw-button-secondary">Sign in</a>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main id="main-content" class="min-h-screen">
+      {% block content %}{% endblock content %}
+    </main>
+
+    <footer class="bw-footer">
+      <div class="bw-container grid gap-10 py-12 md:grid-cols-[1.2fr_0.8fr_0.8fr] lg:py-16">
+        <div>
+          <a href="{% url 'home' %}" class="inline-flex items-center gap-3 font-black">
+            <img class="h-10 w-10" src="{% static 'vendors/images/logo.png' %}" alt="Built with Django Logo" />
+            <span>Built with Django</span>
+          </a>
+          <p class="mt-4 max-w-md text-sm leading-6 text-[oklch(82%_0.03_126)]">
+            A community showcase for Django projects, guides, jobs, and the builders behind them.
+          </p>
+          <p class="mt-6 text-xs text-[oklch(70%_0.025_126)]">
+            &copy; 2026 <a href="https://lvtd.dev">LVTD, LLC</a>. Curated by <a href="https://rasulkireev.com">Rasul Kireev</a>.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-sm font-black uppercase tracking-wider text-[oklch(94%_0.025_126)]">Explore</h2>
+          <div class="mt-4 grid gap-3 text-sm">
+            <a href="{% url 'projects' %}">Projects</a>
+            <a href="{% url 'blog' %}">Guides</a>
+            <a href="{% url 'jobs' %}">Jobs</a>
+            <a href="{% url 'developers' %}">Developers</a>
+            <a href="{% url 'podcast_episodes' %}">Podcast</a>
+          </div>
+        </div>
+        <div>
+          <h2 class="text-sm font-black uppercase tracking-wider text-[oklch(94%_0.025_126)]">Build with us</h2>
+          <div class="mt-4 grid gap-3 text-sm">
+            <a href="{% url 'submit_project' %}">Submit a project</a>
+            <a href="{% url 'post_job' %}">Post a job</a>
+            <a href="{% url 'advertize' %}">Advertise</a>
+            <a href="https://statushen.com/builtwithdjango">Status</a>
+            <a href="https://github.com/builtwithdjango">GitHub</a>
+            <a href="https://x.com/rasulkireev">X</a>
+          </div>
+        </div>
+      </div>
+      <div class="bw-container border-t border-[oklch(35%_0.035_156)] py-4">
+        <div class="scale-75 origin-left">
+          <webring-css site="https://builtwithdjango.com"></webring-css>
+          <script src="https://djangowebring.com/static/webring.js"></script>
+        </div>
+      </div>
+    </footer>
+
+    {% include "components/bottom-right-corner-ad.html" %}
+
+    {% block schema %}
+      <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Projects Built with Django",
+        "description": "Collection of cool projects people built with Django",
+        "thumbnailUrl": "{{ og_image }}",
+        "url": "https://{{ request.get_host }}",
+        "author": {
+          "@type": "Person",
+          "givenName": "Rasul",
+          "familyName": "Kireev",
+          "url": "https://rasulkireev.com/"
+        }
+      }
+      </script>
+    {% endblock schema %}
+
+    {% block extra_bottom_js %}
+    {% endblock extra_bottom_js %}
+  </body>
 </html>

--- a/templates/blog/all_articles.html
+++ b/templates/blog/all_articles.html
@@ -2,70 +2,44 @@
 {% load static %}
 {% load markdown_extras %}
 {% load cloudinary %}
+
 {% block meta %}
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
-    <title>Built with Django | Articles</title>
-    <meta name="description" content="All articles about Django"/>
+    <title>Django Articles | Built with Django</title>
+    <meta name="description" content="Articles, updates, and Django community notes from Built with Django."/>
     <link rel="canonical" href="https://{{ request.get_host }}/blog/articles/" />
-    <meta property="og:title" content="Built with Django | Articles" />
+    <meta property="og:title" content="Django Articles | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/blog/articles/" />
-    <meta property="og:description" content="All articles about Django"/>
-    <meta name="twitter:title" content="Built with Django | Articles" />
-    <meta name="twitter:description" content="All articles about Django"/>
+    <meta property="og:description" content="Articles, updates, and Django community notes from Built with Django."/>
+    <meta name="twitter:title" content="Django Articles | Built with Django" />
+    <meta name="twitter:description" content="Articles, updates, and Django community notes from Built with Django."/>
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
+<section class="bw-page-hero">
+  <div class="bw-container">
+    <p class="bw-kicker">Articles</p>
+    <h1 class="bw-heading-lg mt-3">Django notes from the community</h1>
+    <p class="bw-lede mt-5">Articles, updates, and collected context for people following the Django ecosystem.</p>
+  </div>
+</section>
 
-    <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
-      <div class="mx-auto max-w-2xl text-center">
-        <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Articles</h1>
-        <p class="mt-6 text-lg leading-8 text-gray-600 prose">All articles, updates, and content from Built with Django.</p>
-      </div>
-    </div>
-
-    <div class="relative mx-auto max-w-6xl">
-        <div class="divide-y divide-gray-200">
-            <div class="grid grid-cols-1 gap-6 mb-10 md:grid-cols-2">
-                {% for article in object_list %}
-                <div class="flex bg-white rounded-md border border-gray-100 shadow group">
-                    {% if article.icon %}
-                    <div class="flex flex-shrink-0 items-center p-4 bg-gray-100 lg:p-4">
-                      <!-- Heroicon name: outline/globe-alt -->
-                      <img class="flex-shrink-0 mx-auto w-8 h-8 lg:h-16 lg:w-16"
-                          src="https://res.cloudinary.com/built-with-django/{{ article.icon }}"
-                          alt="" />
-                    </div>
-                    {% endif %}
-                    <div class="flex flex-col flex-1 justify-between p-6 bg-white">
-                      <div class="flex-1">
-                        <a href="{% url 'post' article.slug %}" class="block">
-                          <p class="text-xl font-semibold text-gray-900">{{ article.title }}</p>
-                          <p class="mt-2 text-sm text-gray-500">{{ article.description | truncatechars:300 | markdown | safe }}</p>
-                        </a>
-                      </div>
-                      <div class="mt-4">
-                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-medium text-blue-800 bg-blue-100 rounded-full">
-                          {{ article.get_type_display }}
-                        </span>
-                        {% if article.level %}
-                        <span class="inline-flex items-center px-2.5 py-0.5 text-xs font-medium text-gray-800 bg-gray-100 rounded-full">
-                          {{ article.get_level_display }}
-                        </span>
-                        {% endif %}
-                      </div>
-                    </div>
-                </div>
-                {% empty %}
-                <div class="col-span-2 py-12 text-center">
-                    <p class="text-lg text-gray-500">No articles yet. Check back soon!</p>
-                </div>
-                {% endfor %}
-            </div>
+<section class="pb-16">
+  <div class="bw-container">
+    <div class="grid gap-4 md:grid-cols-2">
+      {% for article in object_list %}
+        {% include "components/post-card.html" with item=article %}
+      {% empty %}
+        <div class="bw-surface p-8 text-center md:col-span-2">
+          <p class="text-lg font-bold bw-muted">No articles yet. Check back soon.</p>
         </div>
+      {% endfor %}
     </div>
+  </div>
+</section>
 {% endblock content %}
 
 {% block schema %}
@@ -75,8 +49,8 @@
     "@type": "WebSite",
     "name": "Built with Django | Articles",
     "about": "Articles",
-    "description": "All articles about Django",
-    "abstract": "All articles about Django",
+    "description": "Articles, updates, and Django community notes from Built with Django.",
+    "abstract": "Articles, updates, and Django community notes from Built with Django.",
     "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}/blog/articles/",
     "author": {

--- a/templates/blog/all_posts.html
+++ b/templates/blog/all_posts.html
@@ -2,56 +2,44 @@
 {% load static %}
 {% load markdown_extras %}
 {% load cloudinary %}
+
 {% block meta %}
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
-    <title>Built with Django | Blog</title>
-    <meta name="description" content="Articles about Django"/>
+    <title>Django Guides | Built with Django</title>
+    <meta name="description" content="Practical Django guides for people building real products."/>
     <link rel="canonical" href="https://{{ request.get_host }}/blog/" />
-    <meta property="og:title" content="Built with Django | Blog" />
+    <meta property="og:title" content="Django Guides | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/blog/" />
-    <meta property="og:description" content="Articles about Django"/>
-    <meta name="twitter:title" content="Built with Django | Blog" />
-    <meta name="twitter:description" content="Articles about Django"/>
+    <meta property="og:description" content="Practical Django guides for people building real products."/>
+    <meta name="twitter:title" content="Django Guides | Built with Django" />
+    <meta name="twitter:description" content="Practical Django guides for people building real products."/>
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
+<section class="bw-page-hero">
+  <div class="bw-container">
+    <p class="bw-kicker">Django guides</p>
+    <h1 class="bw-heading-lg mt-3">Learn Django by building</h1>
+    <p class="bw-lede mt-5">Tutorials and notes for developers who want practical patterns, not abstract framework tours.</p>
+  </div>
+</section>
 
-    <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
-      <div class="mx-auto max-w-2xl text-center">
-        <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Guides</h1>
-        <p class="mt-6 text-lg leading-8 text-gray-600 prose">Learn Django, Build Anything: Tutorials for Aspiring Web Developers.</p>
-      </div>
-    </div>
-
-    <div class="relative mx-auto max-w-6xl">
-        <div class="divide-y divide-gray-200">
-            <div class="grid grid-cols-1 gap-6 mb-10 md:grid-cols-2">
-                {% for guide in object_list %}
-                <div class="flex bg-white rounded-md border border-gray-100 shadow group">
-                    {% if guide.icon %}
-                    <div class="flex flex-shrink-0 items-center p-4 bg-gray-100 lg:p-4">
-                      <!-- Heroicon name: outline/globe-alt -->
-                      <img class="flex-shrink-0 mx-auto w-8 h-8 lg:h-16 lg:w-16"
-                          src="https://res.cloudinary.com/built-with-django/{{ guide.icon }}"
-                          alt="" />
-                    </div>
-                    {% endif %}
-                    <div class="flex flex-col flex-1 justify-between p-6 bg-white">
-                      <div class="flex-1">
-                        <a href="{% url 'post' guide.slug %}" class="block">
-                          <p class="text-xl font-semibold text-gray-900">{{ guide.title }}</p>
-                          <p class="mt-2 text-sm text-gray-500">{{ guide.description | truncatechars:300 | markdown | safe }}</p>
-                        </a>
-                      </div>
-                    </div>
-                </div>
-                {% endfor %}
-            </div>
+<section class="pb-16">
+  <div class="bw-container">
+    <div class="grid gap-4 md:grid-cols-2">
+      {% for guide in object_list %}
+        {% include "components/post-card.html" with item=guide %}
+      {% empty %}
+        <div class="bw-surface p-8 text-center md:col-span-2">
+          <p class="text-lg font-bold bw-muted">No guides yet. Check back soon.</p>
         </div>
+      {% endfor %}
     </div>
+  </div>
+</section>
 {% endblock content %}
 
 {% block schema %}
@@ -61,8 +49,8 @@
     "@type": "WebSite",
     "name": "Built with Django | Blog",
     "about": "Blog",
-    "description": "Articles about Django",
-    "abstract": "Articles about Django",
+    "description": "Practical Django guides for people building real products.",
+    "abstract": "Practical Django guides for people building real products.",
     "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}/blog/",
     "author": {

--- a/templates/blog/post_detail.html
+++ b/templates/blog/post_detail.html
@@ -19,31 +19,48 @@
     <meta property="og:image" content="https://osig.app/g?style=base&site=facebook&font=markerfelt&title={{ object.title }}&subtitle={{ object.description }}&eyebrow=Article" />
 {% endblock meta %}
 
-{% block style %}
-<style>
-
-</style>
-{% endblock style %}
-
 {% block content %}
-    <p class="mt-4 text-blue-700">
-        ←
-        <a href="{% url 'blog' %}">back to all posts</a>
-    </p>
-
-    {# djlint:off #}
-    <div data-controller="exit-intent" data-action="mouseout@document->exit-intent#openModal">
-    {# djlint:on #}
-
-        <div class="p-10 mx-auto mt-10 max-w-4xl bg-white rounded-lg border border-gray-200 border-solid shadow">
-            <div class="prose md:prose-lg">
-                <h1>{{ object.title }}</h1>
-                <div class="blog-post">
-                    {{ object.content | markdown | safe }}
-                </div>
-            </div>
-          </div>
+<section class="bw-page-hero pb-8">
+  <div class="bw-container">
+    <a href="{% url 'blog' %}" class="inline-flex items-center gap-2 text-sm font-black text-[var(--bw-primary-dark)]">
+      <i class="las la-arrow-left" aria-hidden="true"></i>
+      All guides
+    </a>
+    <div class="mt-8 max-w-4xl">
+      <p class="bw-kicker">Django guide</p>
+      <h1 class="bw-heading-lg mt-3">{{ object.title }}</h1>
+      {% if object.description %}
+        <p class="bw-lede mt-5">{{ object.description }}</p>
+      {% endif %}
     </div>
+  </div>
+</section>
+
+{# djlint:off #}
+<div data-controller="exit-intent" data-action="mouseout@document->exit-intent#openModal">
+{# djlint:on #}
+  <section class="pb-16">
+    <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,48rem)_18rem] lg:items-start">
+      <article class="bw-surface p-5 sm:p-8">
+        <div class="bw-prose prose max-w-none md:prose-lg">
+          <div class="blog-post">
+            {{ object.content | markdown | safe }}
+          </div>
+        </div>
+      </article>
+      <aside class="hidden lg:block lg:sticky lg:top-24">
+        <div class="bw-surface p-5">
+          <h2 class="text-xl font-black">Keep learning Django</h2>
+          <p class="mt-2 text-sm leading-6 bw-muted">Browse more guides or study real projects from the community.</p>
+          <div class="mt-5 grid gap-2">
+            <a href="{% url 'blog' %}" class="bw-button bw-button-secondary">More guides</a>
+            <a href="{% url 'projects' %}" class="bw-button bw-button-primary">Project directory</a>
+          </div>
+        </div>
+      </aside>
+    </div>
+  </section>
+</div>
 {% endblock content %}
 
 {% block schema %}

--- a/templates/components/bottom-right-corner-ad.html
+++ b/templates/components/bottom-right-corner-ad.html
@@ -1,131 +1,121 @@
-<div id="ad-container-mobile" class="fixed bottom-0 left-0 z-50 w-full bg-white border shadow-lg transition-all duration-500 ease-in-out lg:hidden">
-  <div class="flex justify-between items-center p-2 mx-auto max-w-6xl">
-    <div class="flex items-center">
-      <div class="mx-4">
-        <a target="_blank" href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'>
-          <img
-            src="https://tuxseo.com/static/vendors/images/logo.png"
-            alt="TuxSEO"
-            class="object-contain mr-2 w-8 h-8"
-          />
-        </a>
-      </div>
-      <div>
-        <p class="text-sm font-bold text-blue-500">
-          <a target="_blank" href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'>
-            TuxSEO
-          </a>
-          <span class="text-sm text-gray-700">- Ad</span>
-        </p>
-        <p class="text-xs text-gray-600">AI-Powered Blog Content Generation.</p>
-      </div>
-    </div>
-    <button class="ml-2 text-gray-500 close-ad hover:text-gray-700">
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-      </svg>
+<aside id="ad-container-mobile" class="fixed inset-x-0 bottom-0 z-50 hidden border-t border-[var(--bw-border)] bg-[var(--bw-surface)] shadow-lg lg:hidden">
+  <div class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3">
+    <a target="_blank"
+       rel="noopener"
+       href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'
+       class="flex min-w-0 items-center gap-3">
+      <img src="https://tuxseo.com/static/vendors/images/logo.png" alt="TuxSEO" class="h-10 w-10 rounded-md object-contain" />
+      <span class="min-w-0">
+        <span class="block text-sm font-black text-[var(--bw-ink)]">TuxSEO <span class="font-bold bw-muted">Ad</span></span>
+        <span class="block truncate text-xs bw-muted">AI-powered blog content generation.</span>
+      </span>
+    </a>
+    <button class="bw-icon-button close-ad shrink-0" type="button" aria-label="Close ad">
+      <i class="las la-times" aria-hidden="true"></i>
     </button>
   </div>
-</div>
+</aside>
 
-<div id="ad-container-desktop" class="hidden fixed right-4 bottom-4 z-50 w-64 bg-white rounded-lg border shadow-lg transition-all duration-500 ease-in-out lg:block">
-  <div class="flex flex-row items-center">
-    <div class="mx-2">
-      <a target="_blank" href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'>
-        <img
-          src="https://tuxseo.com/static/vendors/images/logo.png"
-          alt="TuxSEO"
-          class="object-contain w-36 h-36"
-        />
-      </a>
-    </div>
-    <div class="mr-4">
-      <p class="mb-1 text-lg font-bold text-blue-500"><a target="_blank" href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'>TuxSEO</a></p>
-      <p class="text-sm text-gray-600">AI-Powered Blog Content Generation.</p>
+<aside id="ad-container-desktop" class="fixed bottom-4 right-4 z-50 hidden w-72 rounded-lg border border-[var(--bw-border)] bg-[var(--bw-surface)] p-4 shadow-lg lg:block">
+  <p class="text-xs font-black uppercase tracking-wider bw-muted">Ad</p>
+  <div class="mt-2 flex gap-3">
+    <a target="_blank"
+       rel="noopener"
+       href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
+       class="shrink-0">
+      <img src="https://tuxseo.com/static/vendors/images/logo.png" alt="TuxSEO" class="h-14 w-14 rounded-md object-contain" />
+    </a>
+    <div class="min-w-0">
+      <a target="_blank"
+         rel="noopener"
+         href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
+         class="font-black text-[var(--bw-primary-dark)]">TuxSEO</a>
+      <p class="mt-1 text-sm leading-5 bw-muted">AI-powered blog content generation.</p>
     </div>
   </div>
-  <p class="absolute top-1 left-1 p-1 text-sm text-gray-500">Ad</p>
-  <button class="absolute top-1 right-1 text-gray-500 close-ad hover:text-gray-700">
-    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-    </svg>
+  <button class="bw-icon-button close-ad absolute right-2 top-2 h-8 min-h-0 w-8 min-w-0" type="button" aria-label="Close ad">
+    <i class="las la-times" aria-hidden="true"></i>
   </button>
-</div>
+</aside>
 
 <script>
-  document.addEventListener('DOMContentLoaded', (event) => {
+  document.addEventListener('DOMContentLoaded', () => {
     const adContainerMobile = document.getElementById('ad-container-mobile');
     const adContainerDesktop = document.getElementById('ad-container-desktop');
     const closeAdButtons = document.querySelectorAll('.close-ad');
+
+    if (!adContainerMobile || !adContainerDesktop) return;
 
     function hideAd() {
       if (window.innerWidth < 1024) {
         adContainerMobile.style.transform = 'translateY(100%)';
       } else {
-        adContainerDesktop.style.transform = 'scale(0.1) rotate(360deg)';
+        adContainerDesktop.style.transform = 'translateY(8px)';
         adContainerDesktop.style.opacity = '0';
       }
-      setTimeout(() => {
+
+      window.setTimeout(() => {
         adContainerMobile.style.display = 'none';
         adContainerDesktop.style.display = 'none';
-      }, 500);
+      }, 220);
 
-      // Set a cookie to remember the ad was closed
       const date = new Date();
-      date.setTime(date.getTime() + (24 * 60 * 60 * 1000)); // Set expiry to 24 hours
-      const expires = "expires=" + date.toUTCString();
-      document.cookie = "adClosed=true;" + expires + ";path=/";
+      date.setTime(date.getTime() + (24 * 60 * 60 * 1000));
+      document.cookie = `adClosed=true; expires=${date.toUTCString()}; path=/`;
+    }
+
+    function isPastIntro() {
+      return window.scrollY > Math.min(420, window.innerHeight * 0.6);
     }
 
     function showAd() {
       if (window.innerWidth < 1024) {
+        adContainerDesktop.style.display = 'none';
         adContainerMobile.style.display = 'block';
-        setTimeout(() => {
+        window.setTimeout(() => {
           adContainerMobile.style.transform = 'translateY(0)';
-        }, 100);
+        }, 80);
       } else {
+        adContainerMobile.style.display = 'none';
         adContainerDesktop.style.display = 'block';
-        setTimeout(() => {
-          adContainerDesktop.style.transform = 'scale(1) rotate(0deg)';
+        window.setTimeout(() => {
+          adContainerDesktop.style.transform = 'translateY(0)';
           adContainerDesktop.style.opacity = '1';
-        }, 100);
+        }, 80);
       }
     }
 
-    closeAdButtons.forEach(button => {
+    function maybeShowAd() {
+      if (!document.cookie.includes('adClosed=true') && isPastIntro()) {
+        showAd();
+      }
+    }
+
+    closeAdButtons.forEach((button) => {
       button.addEventListener('click', hideAd);
     });
 
-    // Check and show the ad when the page loads
-    if (document.cookie.indexOf("adClosed=true") === -1) {
-      showAd();
-    }
+    maybeShowAd();
 
-    // Adjust layout on window resize
+    window.addEventListener('scroll', maybeShowAd, { passive: true });
+
     window.addEventListener('resize', () => {
-      if (document.cookie.indexOf("adClosed=true") === -1) {
-        if (window.innerWidth < 1024) {
-          adContainerDesktop.style.display = 'none';
-          showAd();
-        } else {
-          adContainerMobile.style.display = 'none';
-          showAd();
-        }
+      if (!document.cookie.includes('adClosed=true') && isPastIntro()) {
+        showAd();
       }
     });
   });
 </script>
 
 <style>
-  #ad-container-mobile, #ad-container-desktop {
-    display: none;
-  }
   #ad-container-mobile {
     transform: translateY(100%);
-    transition: transform 0.5s ease-in-out;
+    transition: transform 220ms var(--bw-ease);
   }
+
   #ad-container-desktop {
-    transform-origin: bottom right;
-    transition: transform 0.5s ease-in-out, opacity 0.5s ease-in-out;
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 180ms var(--bw-ease), transform 220ms var(--bw-ease);
   }
 </style>

--- a/templates/components/job-item.html
+++ b/templates/components/job-item.html
@@ -1,83 +1,70 @@
 {% load static %}
 {% load humanize %}
 
-<li class="
-    relative flex justify-between px-4 py-5 gap-x-6 hover:bg-gray-50 sm:px-6 items-center space-x-3
-    {% if job.paid %} bg-yellow-300 border-yellow-300 hover:bg-yellow-400 hover:border-yellow-400
-    {% else %} bg-white border-gray-300 hover:bg-gray-100 hover:border-gray-400 {% endif %}
-  ">
-  <div class="flex-shrink-0">
+<li>
+  <a href="{{ job.get_absolute_url }}"
+     class="grid gap-4 border-b border-[var(--bw-border)] bg-[var(--bw-surface)] p-4 transition hover:bg-[var(--bw-primary-soft)] sm:grid-cols-[4rem_1fr_auto] sm:items-center sm:p-5">
+    <span class="flex h-14 w-14 items-center justify-center overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface-raised)] text-lg font-black text-[var(--bw-primary-dark)]">
       {% if job.company.logo %}
-      <img class="w-16 h-16 rounded-full"
-           src="{% get_media_prefix %}{{ job.company.logo }}"
-           alt="{{ job.company.name }} Logo" />
+        <img class="h-full w-full object-cover"
+             src="{% get_media_prefix %}{{ job.company.logo }}"
+             alt="{{ job.company.name }} Logo"
+             loading="lazy"
+             decoding="async" />
       {% elif job.company_logo %}
-      <img class="w-16 h-16 rounded-full"
-           src="{{ job.company_logo.build_url }}"
-           alt="{{ job.company_name }}" />
+        <img class="h-full w-full object-cover"
+             src="{{ job.company_logo.build_url }}"
+             alt="{{ job.company_name }}"
+             loading="lazy"
+             decoding="async" />
+      {% else %}
+        {% if job.company.name %}
+          {{ job.company.name|first }}
+        {% elif job.company_name %}
+          {{ job.company_name|first }}
+        {% else %}
+          D
+        {% endif %}
       {% endif %}
-  </div>
-  <div class="flex-1 min-w-0">
-      <a href="{{ job.get_absolute_url }}" class="focus:outline-none">
-          <span class="absolute inset-0" aria-hidden="true"></span>
-          <p class="text-xl font-semibold text-gray-900">
-              {{ job.title }}
-          </p>
-          <div class="flex items-center mb-2 space-x-1">
-              <p class="text-lg text-gray-600">
-                  {% if job.company.name %}
-                    {{ job.company.name }}
-                  {% elif job.company_name %}
-                    {{ job.company_name }}
-                  {% endif %}
-              </p>
-            </div>
-            <div class="flex flex-col justify-between space-y-4 md:space-y-0 md:flex-row">
-              <div class="flex flex-col items-start space-y-4 md:space-y-0 md:space-x-4 md:items-center md:flex-row">
-                {% if not job.location and not job.min_yearly_salary %}
-                <p></p>
-                {% endif %}
-                {% if job.location %}
-                <p class="flex items-center text-sm text-gray-500">
-                    <svg class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        aria-hidden="true">
-                        <path fill-rule="evenodd"
-                              d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
-                              clip-rule="evenodd"/>
-                    </svg>
-                    {{ job.location | truncatechars:100 }}
-                </p>
-                {% endif %}
-                {% if job.min_yearly_salary %}
-                <p class="flex items-center text-sm text-gray-500">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  {% if job.min_yearly_salary %}{{ job.min_yearly_salary | intcomma }}{% endif %}
-                  {% if job.max_yearly_salary %}- {{ job.max_yearly_salary | intcomma }}{% endif %}
-                </p>
-                {% endif %}
-              </div>
-              <div class="flex flex-col items-start space-y-4 md:space-y-0 md:space-x-4 md:items-center md:flex-row">
-                <p class="flex items-center text-sm text-gray-500">
-                    <!-- Heroicon name: solid/location-marker -->
-                    <svg xmlns="http://www.w3.org/2000/svg"
-                        class="flex-shrink-0 mr-1.5 h-5 w-5 text-gray-400"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor">
-                        <path stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                    </svg>
-                    {{ job.submitted_datetime|timesince }} ago
-                </p>
-              </div>
-            </div>
-      </a>
-  </div>
+    </span>
+
+    <span class="min-w-0">
+      <span class="flex flex-wrap items-center gap-2">
+        <span class="text-xl font-black leading-tight text-[var(--bw-ink)]">{{ job.title }}</span>
+        {% if job.paid %}
+          <span class="rounded-md bg-[var(--bw-accent)] px-2 py-1 text-xs font-black text-[var(--bw-ink)]">Featured</span>
+        {% endif %}
+      </span>
+      <span class="mt-1 block text-base font-bold bw-muted">
+        {% if job.company.name %}
+          {{ job.company.name }}
+        {% elif job.company_name %}
+          {{ job.company_name }}
+        {% endif %}
+      </span>
+      <span class="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm bw-muted">
+        {% if job.location %}
+          <span class="inline-flex items-center gap-1.5">
+            <i class="las la-map-marker" aria-hidden="true"></i>
+            {{ job.location | truncatechars:80 }}
+          </span>
+        {% endif %}
+        {% if job.min_yearly_salary %}
+          <span class="inline-flex items-center gap-1.5">
+            <i class="las la-dollar-sign" aria-hidden="true"></i>
+            {{ job.min_yearly_salary | intcomma }}{% if job.max_yearly_salary %} - {{ job.max_yearly_salary | intcomma }}{% endif %}
+          </span>
+        {% endif %}
+        <span class="inline-flex items-center gap-1.5">
+          <i class="las la-clock" aria-hidden="true"></i>
+          {{ job.submitted_datetime|timesince }} ago
+        </span>
+      </span>
+    </span>
+
+    <span class="hidden text-sm font-black text-[var(--bw-primary-dark)] sm:inline-flex">
+      View role
+      <i class="las la-arrow-right ml-1" aria-hidden="true"></i>
+    </span>
+  </a>
 </li>

--- a/templates/components/job-item.html
+++ b/templates/components/job-item.html
@@ -55,10 +55,12 @@
             {{ job.min_yearly_salary | intcomma }}{% if job.max_yearly_salary %} - {{ job.max_yearly_salary | intcomma }}{% endif %}
           </span>
         {% endif %}
-        <span class="inline-flex items-center gap-1.5">
-          <i class="las la-clock" aria-hidden="true"></i>
-          {{ job.submitted_datetime|timesince }} ago
-        </span>
+        {% if job.submitted_datetime %}
+          <span class="inline-flex items-center gap-1.5">
+            <i class="las la-clock" aria-hidden="true"></i>
+            {{ job.submitted_datetime|timesince }} ago
+          </span>
+        {% endif %}
       </span>
     </span>
 

--- a/templates/components/newsletter.html
+++ b/templates/components/newsletter.html
@@ -1,27 +1,29 @@
 {% load widget_tweaks %}
-<div class="bg-white">
-  <div class="max-w-6xl py-12 mx-auto lg:py-16">
-    <div class="px-6 py-6 bg-green-700 rounded-lg md:py-12 md:px-12 lg:py-16 lg:px-16 xl:flex xl:items-center">
-      <div class="xl:w-0 xl:flex-1">
-        <h2 class="text-2xl font-extrabold tracking-tight text-white sm:text-3xl">Want updates on the latest jobs and guides?</h2>
-        <p class="max-w-3xl mt-3 text-lg leading-6 text-green-200">Sign up for our newsletter to stay up to date.</p>
+
+<section class="bw-section">
+  <div class="bw-container">
+    <div class="grid gap-8 rounded-lg border border-[var(--bw-border)] bg-[var(--bw-primary-dark)] p-6 text-[oklch(98%_0.01_118)] shadow-lg md:grid-cols-[1fr_0.9fr] md:p-8 lg:p-10">
+      <div>
+        <p class="text-sm font-black uppercase tracking-wider text-[var(--bw-accent)]">Newsletter</p>
+        <h2 class="mt-3 text-3xl font-black leading-tight sm:text-4xl">Get useful Django projects, jobs, and guides in your inbox.</h2>
+        <p class="mt-4 max-w-2xl text-base leading-7 text-[oklch(88%_0.035_135)]">
+          A practical digest for people learning, hiring, or building with Django. No generic startup noise.
+        </p>
       </div>
-      <div class="mt-8 sm:w-full sm:max-w-md xl:mt-0 xl:ml-8">
-        <form class="sm:flex" action="{% url 'newsletter_home' %}" method="post" enctype="multipart/form-data">
-          {% csrf_token %} {{ newsletter_form.non_field_errors }}
+      <div class="self-center">
+        <form class="grid gap-3 sm:grid-cols-[1fr_auto]" action="{% url 'newsletter_home' %}" method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ newsletter_form.non_field_errors }}
           <label for="email-address" class="sr-only">Email address</label>
-          {% render_field newsletter_form.user_email id="email-address" name="email-address" type="email" autocomplete="email" required=True class="w-full px-5 py-3 placeholder-gray-500 border-white rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-700 focus:ring-white" placeholder="Enter your email" %}
-          <button type="submit" class="flex items-center justify-center w-full px-5 py-3 mt-3 text-base font-medium text-white bg-green-500 border border-transparent rounded-md shadow hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-700 focus:ring-white sm:mt-0 sm:ml-3 sm:w-auto sm:flex-shrink-0">Sign up</button>
+          {% render_field newsletter_form.user_email id="email-address" name="email-address" type="email" autocomplete="email" required=True class="min-h-[3rem] w-full rounded-md border border-[oklch(92%_0.035_135)] bg-[oklch(99%_0.008_118)] px-4 py-3 text-[var(--bw-ink)] placeholder:text-[var(--bw-muted)] focus:border-[var(--bw-accent)] focus:ring-[var(--bw-accent)]" placeholder="you@example.com" %}
+          <button type="submit" class="bw-button bw-button-accent">Join free</button>
         </form>
         {% if user.is_superuser %}
-        <div>
-          <a class="inline-flex items-center px-4 py-2 text-base font-medium text-green-700 bg-green-200 border border-transparent border-solid rounded-md hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-             href="{% url 'get-weekly-template' %}">
-              Get Weekly Email
-          </a>
-        </div>
+          <div class="mt-4">
+            <a class="bw-button bw-button-secondary" href="{% url 'get-weekly-template' %}">Get weekly email</a>
+          </div>
         {% endif %}
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/templates/components/post-card.html
+++ b/templates/components/post-card.html
@@ -1,0 +1,31 @@
+{% load markdown_extras %}
+
+<article class="bw-card flex min-h-full flex-col sm:flex-row">
+  {% if item.icon %}
+    <a href="{% url 'post' item.slug %}" class="flex min-h-[6rem] items-center justify-center bg-[var(--bw-surface-muted)] p-5 sm:w-32 sm:shrink-0" aria-label="Read {{ item.title }}">
+      <img class="h-14 w-14 object-contain"
+           src="https://res.cloudinary.com/built-with-django/{{ item.icon }}"
+           alt=""
+           loading="lazy"
+           decoding="async" />
+    </a>
+  {% endif %}
+  <div class="flex flex-1 flex-col justify-between p-5">
+    <div>
+      <h2 class="text-xl font-black leading-tight text-[var(--bw-ink)]">
+        <a href="{% url 'post' item.slug %}">{{ item.title }}</a>
+      </h2>
+      <div class="bw-prose mt-3 text-sm leading-6">
+        {{ item.description | truncatechars:220 | markdown | safe }}
+      </div>
+    </div>
+    <div class="mt-4 flex flex-wrap gap-2">
+      {% if item.get_type_display %}
+        <span class="rounded-md bg-[var(--bw-primary-soft)] px-2.5 py-1 text-xs font-black text-[var(--bw-primary-dark)]">{{ item.get_type_display }}</span>
+      {% endif %}
+      {% if item.level %}
+        <span class="rounded-md bg-[var(--bw-surface-muted)] px-2.5 py-1 text-xs font-black text-[var(--bw-ink-soft)]">{{ item.get_level_display }}</span>
+      {% endif %}
+    </div>
+  </div>
+</article>

--- a/templates/components/project-card.html
+++ b/templates/components/project-card.html
@@ -1,0 +1,59 @@
+{% load static %}
+
+<article class="bw-card bw-project-card {% if site.sponsored %}bw-project-card--sponsored{% endif %}">
+  <a href="{% url 'project' site.slug %}" class="bw-project-card__media" aria-label="View {{ site.title }}">
+    {% if site.homepage_screenshot %}
+      <img
+        src="{% get_media_prefix %}{{ site.homepage_screenshot }}"
+        alt="{{ site.title }} screenshot"
+        loading="lazy"
+        decoding="async"
+      />
+    {% else %}
+      <div class="flex h-full items-center justify-center bg-[var(--bw-surface-muted)] p-6 text-center text-sm font-bold bw-muted">
+        Screenshot coming soon
+      </div>
+    {% endif %}
+  </a>
+  <div class="bw-project-card__body">
+    <div class="flex items-start justify-between gap-3">
+      <h2 class="m-0">
+        <a href="{% url 'project' site.slug %}" class="bw-project-card__title">{{ site.title }}</a>
+      </h2>
+      {% if site.sponsored %}
+        <span class="shrink-0 rounded-md bg-[var(--bw-accent)] px-2 py-1 text-xs font-black text-[var(--bw-ink)]">Featured</span>
+      {% endif %}
+    </div>
+    <p class="text-sm leading-6 bw-muted">{{ site.short_description }}</p>
+  </div>
+  <div class="bw-project-card__actions">
+    <div class="flex flex-wrap items-center gap-2">
+      <a class="bw-icon-button"
+         href='{{ site.url }}?ref={{ request.get_host }}&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=list-of-projects-{% now "F-Y" %}-{% if site.sponsored %}sponsored{% else %}unsponsored{% endif %}'
+         target="_blank"
+         rel="noopener"
+         aria-label="Visit {{ site.title }}">
+        <i class="las la-external-link-alt" aria-hidden="true"></i>
+      </a>
+      {% if site.github_url %}
+        <a class="bw-icon-button"
+           href="{{ site.github_url }}?ref={{ request.get_host }}"
+           target="_blank"
+           rel="noopener"
+           aria-label="{{ site.title }} on GitHub">
+          <i class="lab la-github" aria-hidden="true"></i>
+        </a>
+      {% endif %}
+      {% if site.twitter_url %}
+        <a class="bw-icon-button"
+           href="{{ site.twitter_url }}?ref={{ request.get_host }}"
+           target="_blank"
+           rel="noopener"
+           aria-label="{{ site.title }} on X">
+          <i class="lab la-twitter" aria-hidden="true"></i>
+        </a>
+      {% endif %}
+    </div>
+    {% include "components/project-likes.html" with site=site %}
+  </div>
+</article>

--- a/templates/components/project-likes.html
+++ b/templates/components/project-likes.html
@@ -1,112 +1,58 @@
 {% load static %}
 {% load widget_tweaks %}
 
-<div class="flex flex-row space-x-2">
-  <div data-controller="like"
-      class="flex items-center p-2 text-lg border border-gray-300 border-solid rounded-lg hover:border-gray-600 hover:bg-gray-100">
-      <input type="hidden" data-like-target="projectId" value={{ site.id }} />
-      <input type="hidden" data-like-target="currentUser" value={{ user.id }} />
-      {% csrf_token %}
-      {% if user.is_authenticated %}
-          <button data-action="click->like#modify" class="flex items-center">
-              <span class="text-base" data-like-target="numberOfLikes" id="{{ site.id }}_likes"></span>
-              <i id="{{ site.id }}_heart"></i>
-          </button>
-      {% else %}
-          <button data-action="click->
-              like#toggleModal" data-like-target="modalButton" class="flex items-center">
-              <span class="text-base" data-like-target="numberOfLikes" id="{{ site.id }}_likes"></span>
-              <i id="{{ site.id }}_heart"></i>
-          </button>
-          <div data-like-target="modal"
-               class="fixed inset-0 z-10 hidden overflow-y-auto"
-               aria-labelledby="modal-title"
-               role="dialog"
-               aria-modal="true">
-              <div class="flex items-end justify-center px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-                  <div class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75"
-                       aria-hidden="true"
-                       data-transition-enter="ease-out duration-300"
-                       data-transition-enter-start="opacity-0"
-                       data-transition-enter-end="opacity-100"
-                       data-transition-leave="ease-in duration-200"
-                       data-transition-leave-start="opacity-100"
-                       data-transition-leave-end="opacity-0"></div>
-                  <!-- This element is to trick the browser into centering the modal contents. -->
-                  <span class="hidden sm:inline-block sm:align-middle sm:h-screen"
-                        aria-hidden="true">
-                      &#8203;
-                  </span>
-                  <div class="inline-block overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl sm:my-8 sm:align-middle sm:max-w-lg sm:w-full"
-                       data-transition-enter="ease-out duration-300"
-                       data-transition-enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                       data-transition-enter-end="opacity-100 translate-y-0 sm:scale-100"
-                       data-transition-leave="ease-in duration-200"
-                       data-transition-leave-start="opacity-100 translate-y-0 sm:scale-100"
-                       data-transition-leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-                      <div class="px-4 pt-5 pb-4 bg-white sm:p-6 sm:pb-4">
-                          <div class="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
-                              <button data-action="click->
-                                  like#toggleModal"
-                                  data-like-target="modalButton"
-                                  type="button"
-                                  class="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                                  >
-                                  <span class="sr-only">Close</span>
-                                  <!-- Heroicon name: outline/x -->
-                                  <svg class="w-6 h-6"
-                                       xmlns="http://www.w3.org/2000/svg"
-                                       fill="none"
-                                       viewBox="0 0 24 24"
-                                       stroke="currentColor"
-                                       aria-hidden="true">
-                                      <path stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            stroke-width="2"
-                                            d="M6 18L18 6M6 6l12 12"/>
-                                  </svg>
-                              </button>
-                          </div>
-                          <div class="sm:flex sm:items-start">
-                              <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-                                  <h3 class="text-lg font-medium leading-6 text-gray-900"
-                                      id="modal-title">
-                                      Please login
-                                  </h3>
-                                  <div class="mt-2">
-                                      <p class="text-sm text-gray-500">
-                                          In order to ❤️ projects you need to
-                                          <a class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
-                                             href="{% url 'account_login' %}">
-                                              login
-                                          </a>
-                                          or
-                                          <a href="{% url 'account_signup' %}"
-                                             class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-200 text-green-800">
-                                              signup
-                                          </a>
-                                          if you don't have an account yet.
-                                      </p>
-                                  </div>
-                              </div>
-                          </div>
-                      </div>
-                      <div class="px-4 py-3 bg-gray-50 sm:px-6 sm:flex sm:flex-row-reverse">
-                          <a href="{% url 'account_login' %}"
-                             class="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-green-600 border border-transparent rounded-md shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-                              Login
-                          </a>
-                          <button data-action="click->
-                              like#toggleModal"
-                              data-like-target="modalButton"
-                              type="button"
-                              class="inline-flex justify-center w-full px-4 py-2 mt-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-                              Cancel
-                          </button>
-                      </div>
-                  </div>
+<div data-controller="like" class="inline-flex">
+  <input type="hidden" data-like-target="projectId" value="{{ site.id }}" />
+  <input type="hidden" data-like-target="currentUser" value="{{ user.id }}" />
+  {% csrf_token %}
+  {% if user.is_authenticated %}
+    <button data-action="click->like#modify" class="bw-icon-button gap-1" type="button" aria-label="Like {{ site.title }}">
+      <span class="text-sm font-black" data-like-target="numberOfLikes" id="{{ site.id }}_likes"></span>
+      <i id="{{ site.id }}_heart" aria-hidden="true"></i>
+    </button>
+  {% else %}
+    <button data-action="click->like#toggleModal" data-like-target="modalButton" class="bw-icon-button gap-1" type="button" aria-label="Like {{ site.title }}">
+      <span class="text-sm font-black" data-like-target="numberOfLikes" id="{{ site.id }}_likes"></span>
+      <i id="{{ site.id }}_heart" aria-hidden="true"></i>
+    </button>
+    <div data-like-target="modal"
+         class="fixed inset-0 z-50 hidden overflow-y-auto"
+         aria-labelledby="modal-title"
+         role="dialog"
+         aria-modal="true">
+      <div class="flex min-h-screen items-end justify-center px-4 pb-20 pt-4 text-center sm:block sm:p-0">
+        <div class="fixed inset-0 bg-[oklch(20%_0.035_156_/_0.64)] transition-opacity" aria-hidden="true"></div>
+        <span class="hidden sm:inline-block sm:h-screen sm:align-middle" aria-hidden="true">&#8203;</span>
+        <div class="inline-block w-full max-w-lg transform overflow-hidden rounded-lg bg-[var(--bw-surface)] text-left align-bottom shadow-xl transition-all sm:my-8 sm:align-middle">
+          <div class="p-6">
+            <div class="flex items-start justify-between gap-6">
+              <div>
+                <h3 class="text-xl font-black text-[var(--bw-ink)]" id="modal-title">Sign in to save projects</h3>
+                <p class="mt-2 text-sm leading-6 bw-muted">
+                  Liking projects helps you build a personal shortlist and gives makers a signal that their work is useful.
+                </p>
               </div>
+              <button data-action="click->like#toggleModal"
+                      data-like-target="modalButton"
+                      type="button"
+                      class="bw-icon-button shrink-0"
+                      aria-label="Close dialog">
+                <i class="las la-times" aria-hidden="true"></i>
+              </button>
+            </div>
           </div>
-      {% endif %}
-  </div>
+          <div class="flex flex-col-reverse gap-2 border-t border-[var(--bw-border)] bg-[var(--bw-surface-raised)] p-4 sm:flex-row sm:justify-end">
+            <button data-action="click->like#toggleModal"
+                    data-like-target="modalButton"
+                    type="button"
+                    class="bw-button bw-button-secondary">
+              Keep browsing
+            </button>
+            <a href="{% url 'account_login' %}" class="bw-button bw-button-primary">Sign in</a>
+            <a href="{% url 'account_signup' %}" class="bw-button bw-button-accent">Create account</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
 </div>

--- a/templates/developers/all_developers.html
+++ b/templates/developers/all_developers.html
@@ -3,68 +3,67 @@
 {% load markdown_extras %}
 
 {% block meta %}
-    <title>Django Developers</title>
-    <meta name="description" content="Hire the best Django Developers this world has to offer!"/>
+    <title>Django Developers | Built with Django</title>
+    <meta name="description" content="Discover Django developers available for work."/>
     <link rel="canonical" href="https://{{ request.get_host }}/developers/" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Developers" />
-    <meta name="twitter:description" content="Hire the best Django Developers this world has to offer!"/>
+    <meta name="twitter:title" content="Django Developers | Built with Django" />
+    <meta name="twitter:description" content="Discover Django developers available for work."/>
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django Jobs" />
+    <meta property="og:title" content="Django Developers | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/developers/" />
-    <meta property="og:description" content="Hire the best Django Developers this world has to offer!"/>
+    <meta property="og:description" content="Discover Django developers available for work."/>
     <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
-<div class="px-6 py-20 bg-white lg:px-8">
-  <div class="max-w-2xl mx-auto text-center">
-    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Developers</h1>
-    <p class="mt-6 text-lg leading-8 prose text-gray-600">Hire the best Django Developers this world has to offer.</p>
-    <p class="text-lg leading-8 prose text-gray-600">This page is influnced by <a href="https://masilotti.com">Joe Masilotti's</a> <a href="https://railsdevs.com">RailsDevs.</a></p>
+<section class="bw-page-hero">
+  <div class="bw-container grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
+    <div>
+      <p class="bw-kicker">Developer directory</p>
+      <h1 class="bw-heading-lg mt-3">Hire Django people</h1>
+      <p class="bw-lede mt-5">
+        A community directory for developers who know Django and teams looking for practical web builders.
+      </p>
+    </div>
+    <a href="{% url 'update-profile' %}" class="bw-button bw-button-accent">Create your profile</a>
   </div>
-  <div class="flex flex-wrap items-center justify-between mt-8 sm:flex-nowrap">
-      <div class="mx-auto">
-        <a type="button"
-            href="{% url 'update-profile' %}"
-            class="flex items-center justify-center w-full px-5 py-3 mt-3 text-base font-medium text-white bg-green-500 border border-transparent rounded-md shadow hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-700 focus:ring-white sm:mt-0 sm:ml-3 sm:w-auto sm:flex-shrink-0">
-            Create Your Profile
-        </a>
-      </div>
-  </div>
-</div>
+</section>
 
-<div class="overflow-hidden bg-white border border-gray-300 rounded-md">
-  <ul role="list" class="divide-y divide-gray-300">
-    {% for developer in object_list %}
-    <li>
-      <a class="flex px-6 py-4 space-x-4 bg-white hover:bg-gray-50 sm:space-x-8" href="{% url 'developer' developer.id %}">
-        <div class="flex items-center justify-center shrink-0">{% include "components/profile-image.html" with user=developer.user size=40 %}</div>
-        <div class="self-start flex-1 min-w-0 space-y-3">
-          <div class="flex items-baseline">
-            <h2 class="text-xl font-medium text-gray-900 sm:text-xl line-clamp-2 break-word" title="{{ developer.title }}">{{ developer.title }}</h2>
-            <div class="flex-row-reverse items-center hidden ml-auto text-gray-400 sm:inline-flex shrink-0">
-                <div class="flex items-center space-x-2">
-                  {% include "components/developer-status.html" with developer=developer %}
-                </div>
-            </div>
-          </div>
-          <div class="flex flex-col items-start space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
-            {% comment %} Any special tags {% endcomment %}
-          </div>
-          <div class="flex items-center justify-between">
-            <div class="space-y-4 text-lg text-gray-700 sm:text-base">
-              <p class="break-words line-clamp-3">{{ developer.description | truncatechars:400 }}</p>
-            </div>
-          </div>
-        </div>
-      </a>
-    </li>
-    {% endfor %}
-  </ul>
-</div>
+<section class="pb-16">
+  <div class="bw-container">
+    <div class="overflow-hidden rounded-lg border border-[var(--bw-border)] bg-[var(--bw-surface)] shadow-sm">
+      <ul role="list" class="divide-y divide-[var(--bw-border)]">
+        {% for developer in object_list %}
+          <li>
+            <a class="grid gap-4 p-4 transition hover:bg-[var(--bw-primary-soft)] sm:grid-cols-[4rem_1fr_auto] sm:items-start sm:p-5" href="{% url 'developer' developer.id %}">
+              <span class="flex h-14 w-14 items-center justify-center overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface-raised)]">
+                {% include "components/profile-image.html" with user=developer.user size=40 %}
+              </span>
+              <span class="min-w-0">
+                <span class="flex flex-wrap items-center gap-3">
+                  <span class="text-xl font-black leading-tight text-[var(--bw-ink)]">{{ developer.title }}</span>
+                  <span class="hidden sm:inline-flex">{% include "components/developer-status.html" with developer=developer %}</span>
+                </span>
+                <span class="mt-2 block text-sm leading-6 bw-muted">{{ developer.description | truncatechars:300 }}</span>
+              </span>
+              <span class="hidden text-sm font-black text-[var(--bw-primary-dark)] sm:inline-flex">
+                View profile
+                <i class="las la-arrow-right ml-1" aria-hidden="true"></i>
+              </span>
+            </a>
+          </li>
+        {% empty %}
+          <li class="p-8 text-center">
+            <p class="text-lg font-bold bw-muted">No developer profiles are live yet.</p>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</section>
 {% endblock content %}
 
 {% block schema %}
@@ -74,8 +73,8 @@
     "@type": "WebSite",
     "name": "Django Developers",
     "about": "Reverse Job Board",
-    "description": "Hire the best Django Developers this world has to offer!",
-    "abstract": "Hire the best Django Developers this world has to offer!",
+    "description": "Discover Django developers available for work.",
+    "abstract": "Discover Django developers available for work.",
     "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}/developers/",
     "author": {

--- a/templates/developers/developer_detail.html
+++ b/templates/developers/developer_detail.html
@@ -5,7 +5,7 @@
 
 {% block meta %}
     <title>{{ object.title }}</title>
-    <meta name="description" content="{{ object.desciprition }}"/>
+    <meta name="description" content="{{ object.description }}"/>
     <link rel="canonical" href="https://{{ request.get_host }}/developers/{{ object.id }}" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
@@ -20,157 +20,108 @@
 {% endblock meta %}
 
 {% block content %}
-<main class="flex-1">
-  <div class="py-8 xl:py-10">
-    <div class="max-w-3xl px-4 mx-auto sm:px-6 lg:px-8 xl:grid xl:max-w-5xl xl:grid-cols-3">
-      <div class="xl:col-span-2 xl:border-r xl:border-gray-200 xl:pr-8">
+<section class="bw-page-hero pb-10">
+  <div class="bw-container">
+    <a href="{% url 'developers' %}" class="inline-flex items-center gap-2 text-sm font-black text-[var(--bw-primary-dark)]">
+      <i class="las la-arrow-left" aria-hidden="true"></i>
+      All developers
+    </a>
+    <div class="mt-8 grid gap-8 lg:grid-cols-[1fr_auto] lg:items-start">
+      <div class="flex flex-col gap-5 sm:flex-row sm:items-center">
+        <span class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)]">
+          {% include "components/profile-image.html" with user=object.user size=20 %}
+        </span>
         <div>
-          <div>
-            <div class="md:flex md:items-end md:space-x-4 xl:border-b xl:pb-6">
-              {% include "components/profile-image.html" with user=object.user size=20 %}
-              <h1 class="text-2xl font-bold text-gray-900">{{ object.title }}</h1>
-              <div class="flex mt-4 space-x-3 md:mt-0">
-                {% if user == object.user %}
-                <a href="{% url 'update-profile' %}" class="inline-flex justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                  <svg class="-ml-0.5 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                    <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
-                  </svg>
-                  Edit
-                </a>
-                {% endif %}
-                {% comment %} <button type="button" class="inline-flex justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" class="-ml-0.5 h-5 w-5 text-gray-400" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 00.75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 00-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0112 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 01-.673-.38m0 0A2.18 2.18 0 013 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 013.413-.387m7.5 0V5.25A2.25 2.25 0 0013.5 3h-3a2.25 2.25 0 00-2.25 2.25v.894m7.5 0a48.667 48.667 0 00-7.5 0M12 12.75h.008v.008H12v-.008z" />
-                  </svg>
-                  Hire Me
-                </button> {% endcomment %}
-              </div>
-            </div>
-            <div class="py-3 xl:pt-6 xl:pb-0">
-              <h2 class="sr-only">Description</h2>
-              <div class="prose max-w-none">
-                <p>{{ object.description | markdown | safe }}</p>
-              </div>
-            </div>
-          </div>
+          <p class="bw-kicker">Django developer</p>
+          <h1 class="mt-3 text-3xl font-black leading-tight text-[var(--bw-ink)] sm:text-5xl">{{ object.title }}</h1>
         </div>
       </div>
-      <aside class="block xl:pl-8">
-        <h2 class="sr-only">Details</h2>
-        <div class="space-y-2">
-          {% include "components/developer-status.html" with text_size="sm" title=True developer=object %}
-          <div class="flex items-center space-x-2">
-            <span class="text-sm font-medium text-gray-700">
-              Experience:
-            </span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
-            </svg>
-            <span class="text-sm font-medium text-gray-700">
-              {{ object.get_role_display }}
-            </span>
-          </div>
-          <div class="flex items-center space-x-2">
-            <span class="text-sm font-medium text-gray-700">
-              Salary Expecation:
-            </span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <span class="text-sm font-medium text-gray-700">
-              ${{ object.salary_expectation | intcomma }} / {{ object.get_salary_cadence_display }}
-            </span>
-          </div>
-          <div>
-            <span class="text-sm font-medium text-gray-700">
-              Capacity:
-            </span>
-            <ul role="list" class="mt-3 ml-3 space-y-3">
-              {% for item in developer_capacity %}
-              <li class="flex items-center space-x-2">
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0012 15.75a7.488 7.488 0 00-5.982 2.975m11.963 0a9 9 0 10-11.963 0m11.963 0A8.966 8.966 0 0112 21a8.966 8.966 0 01-5.982-2.275M15 9.75a3 3 0 11-6 0 3 3 0 016 0z" />
-                  </svg>
-                  <span class="text-sm font-medium text-gray-700">
-                  {% if item == "PTC" %}
-                    Part-time Contractor
-                  {% elif item == "FTC" %}
-                    Full-time Contractor
-                  {% elif item == "PTE" %}
-                    Part-time Employee
-                  {% elif item == "FTE" %}
-                    Full-time Employee
-                  {% endif %}
-                  </span>
-                </li>
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
-        <div class="py-6 mt-6 space-y-2 border-t border-gray-200">
-          {% comment %} {% if user.has_active_django_devs_subscription or user == object.user %} {% endcomment %}
-            <div class="flex items-center space-x-2">
-              <span class="text-sm font-medium text-gray-700">
-                Name:
-              </span>
-              <span class="text-sm font-medium text-gray-700">
-                {{ object.user.first_name }} {{ object.user.last_name }}
-              </span>
-            </div>
-            <div class="flex items-center space-x-2">
-              <span class="text-sm font-medium text-gray-700">
-                Email:
-              </span>
-              <span class="text-sm font-medium text-gray-700">
-                {{ object.user.email }}
-              </span>
-            </div>
-            <div>
-              <span class="text-sm font-medium text-gray-700">
-                Social Links:
-              </span>
-              <ul role="list" class="mt-3 ml-3 space-y-3 prose">
-                    {% if object.user.twitter_handle %}
-                    <li class="flex items-center space-x-1">
-                      <i class="lab la-lg la-twitter"></i>
-                      <a href="https://twitter.com/{{ object.user.twitter_handle }}" class="text-sm font-medium text-gray-700">
-                        Twitter
-                      </a>
-                    </li>
-                    {% endif %}
-                    {% if object.user.github_handle %}
-                    <li class="flex items-center space-x-1">
-                      <i class="lab la-lg la-github"></i>
-                      <a href="https://github.com/{{ object.user.github_handle }}" class="text-sm font-medium text-gray-700">
-                        Github
-                      </a>
-                    </li>
-                    {% endif %}
-                    {% if object.user.personal_website %}
-                    <li class="flex items-center space-x-1">
-                      <i class="las la-lg la-link"></i>
-                      <a href="{{ object.user.personal_website }}" class="text-sm font-medium text-gray-700">
-                        Personal Website
-                      </a>
-                    </li>
-                    {% endif %}
-              </ul>
-            </div>
-          {% comment %} {% else %}
-            <a class="block w-full px-10 py-6 text-center border-2 border-gray-300 border-dashed rounded-lg group bg-gray-50 hover:border-gray-400" href="/pricing">
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 mx-auto text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-              <span class="block mt-2 text-sm font-medium text-gray-600">Private information</span>
-              <span class="block mt-2 text-sm text-gray-500">Information that is only visible with a business subscription.</span>
-            </a>
-          {% endif %} {% endcomment %}
-        </div>
-
-      </aside>
+      {% if user == object.user %}
+        <a href="{% url 'update-profile' %}" class="bw-button bw-button-secondary">Edit profile</a>
+      {% endif %}
     </div>
   </div>
-</main>
+</section>
+
+<section class="pb-16">
+  <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem]">
+    <article class="bw-surface p-5 sm:p-8">
+      <h2 class="text-2xl font-black text-[var(--bw-ink)]">About</h2>
+      <div class="bw-prose prose mt-4 max-w-none md:prose-lg">
+        {{ object.description | markdown | safe }}
+      </div>
+    </article>
+
+    <aside class="grid content-start gap-4">
+      <section class="bw-surface p-5">
+        <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Availability</h2>
+        <div class="mt-4 grid gap-3 text-sm">
+          {% include "components/developer-status.html" with text_size="sm" title=True developer=object %}
+          <p class="rounded-md bg-[var(--bw-surface-raised)] p-3">
+            <span class="block font-black text-[var(--bw-ink)]">Experience</span>
+            <span class="mt-1 block bw-muted">{{ object.get_role_display }}</span>
+          </p>
+          <p class="rounded-md bg-[var(--bw-surface-raised)] p-3">
+            <span class="block font-black text-[var(--bw-ink)]">Salary expectation</span>
+            <span class="mt-1 block bw-muted">${{ object.salary_expectation | intcomma }} / {{ object.get_salary_cadence_display }}</span>
+          </p>
+        </div>
+      </section>
+
+      {% if developer_capacity %}
+        <section class="bw-surface p-5">
+          <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Capacity</h2>
+          <ul role="list" class="mt-4 grid gap-2">
+            {% for item in developer_capacity %}
+              <li class="rounded-md bg-[var(--bw-primary-soft)] px-3 py-2 text-sm font-bold text-[var(--bw-primary-dark)]">
+                {% if item == "PTC" %}
+                  Part-time contractor
+                {% elif item == "FTC" %}
+                  Full-time contractor
+                {% elif item == "PTE" %}
+                  Part-time employee
+                {% elif item == "FTE" %}
+                  Full-time employee
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </section>
+      {% endif %}
+
+      <section class="bw-surface p-5">
+        <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Contact</h2>
+        <div class="mt-4 grid gap-3 text-sm">
+          <p>
+            <span class="block font-black text-[var(--bw-ink)]">Name</span>
+            <span class="mt-1 block bw-muted">{{ object.user.first_name }} {{ object.user.last_name }}</span>
+          </p>
+          <p>
+            <span class="block font-black text-[var(--bw-ink)]">Email</span>
+            <a href="mailto:{{ object.user.email }}" class="mt-1 block font-bold text-[var(--bw-primary-dark)]">{{ object.user.email }}</a>
+          </p>
+          <div class="flex gap-2">
+            {% if object.user.twitter_handle %}
+              <a href="https://twitter.com/{{ object.user.twitter_handle }}" class="bw-icon-button" aria-label="Twitter profile">
+                <i class="lab la-twitter" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+            {% if object.user.github_handle %}
+              <a href="https://github.com/{{ object.user.github_handle }}" class="bw-icon-button" aria-label="GitHub profile">
+                <i class="lab la-github" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+            {% if object.user.personal_website %}
+              <a href="{{ object.user.personal_website }}" class="bw-icon-button" aria-label="Personal website">
+                <i class="las la-link" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+          </div>
+        </div>
+      </section>
+    </aside>
+  </div>
+</section>
 {% endblock content %}
 
 {% block schema %}

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -3,63 +3,56 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Django Jobs</title>
-    <meta name="description" content="Best jobs for best Django Developers!"/>
+    <title>Django Jobs | Built with Django</title>
+    <meta name="description" content="Django jobs for developers who want to work with Django." />
     <link rel="canonical" href="https://{{ request.get_host }}/jobs/" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Jobs" />
-    <meta name="twitter:description" content="Best jobs for best Django Developers!"/>
+    <meta name="twitter:title" content="Django Jobs | Built with Django" />
+    <meta name="twitter:description" content="Django jobs for developers who want to work with Django." />
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django Jobs" />
+    <meta property="og:title" content="Django Jobs | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/jobs/" />
-    <meta property="og:description" content="Best jobs for best Django Developers!"/>
+    <meta property="og:description" content="Django jobs for developers who want to work with Django." />
     <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
-
-    <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
-      <div class="max-w-2xl mx-auto text-center">
-        <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Jobs</h1>
-        <p class="mt-6 text-lg leading-8 prose text-gray-600">Advertize your jobs to the best Django Developers out there.</p>
-      </div>
-      <div class="flex flex-wrap items-center justify-between mt-8 sm:flex-nowrap">
-          <div class="mx-auto">
-            <a type="button"
-                href="{% url 'post_job' %}"
-                class="flex items-center justify-center w-full px-5 py-3 mt-3 text-base font-medium text-white bg-green-500 border border-transparent rounded-md shadow hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-700 focus:ring-white sm:mt-0 sm:ml-3 sm:w-auto sm:flex-shrink-0">
-                Post a Job
-            </a>
-          </div>
-      </div>
+<section class="bw-page-hero">
+  <div class="bw-container grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
+    <div>
+      <p class="bw-kicker">Django job board</p>
+      <h1 class="bw-heading-lg mt-3">Find teams building with Django</h1>
+      <p class="bw-lede mt-5">
+        Jobs from teams that care about Django experience, practical web development, and shipping real products.
+      </p>
     </div>
+    <a href="{% url 'post_job' %}" class="bw-button bw-button-accent">Post a job</a>
+  </div>
+</section>
 
+<section class="pb-16">
+  <div class="bw-container">
     {% if object_list %}
-    <div class="mx-auto lg:py-8">
-      <div class="grid items-start grid-cols-1 gap-4 lg:grid-cols-4 lg:gap-8">
-        <div class="grid grid-cols-1 gap-4 lg:col-span-4">
-          <div class="grid grid-cols-1 border border-gray-200 shadow sm:rounded-xl lg:col-span-3">
-            <ul role="list" class="overflow-hidden bg-white divide-y divide-gray-100 shadow-sm ring-1 ring-gray-900/5 sm:rounded-xl">
-              {% for job in object_list %}
-                    {% include "components/job-item.html" with job=job %}
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
+      <div class="overflow-hidden rounded-lg border border-[var(--bw-border)] bg-[var(--bw-surface)] shadow-sm">
+        <ul role="list" class="divide-y divide-[var(--bw-border)]">
+          {% for job in object_list %}
+            {% include "components/job-item.html" with job=job %}
+          {% endfor %}
+        </ul>
       </div>
-    </div>
     {% else %}
-        <div class="flex justify-center mx-auto my-10">
-            <p class="text-3xl md:text-4xl">
-                There are currently no jobs available...
-                <span class="font-bold">that we know of</span>
-            </p>
-        </div>
+      <div class="bw-surface p-8 text-center">
+        <h2 class="text-2xl font-black">No jobs are live right now</h2>
+        <p class="mx-auto mt-3 max-w-md bw-muted">The board is quiet today. Post a Django role if your team is hiring.</p>
+        <a href="{% url 'post_job' %}" class="bw-button bw-button-accent mt-6">Post the first job</a>
+      </div>
     {% endif %}
+  </div>
+</section>
 
-    {% include "components/newsletter.html" with newsletter_form=newsletter_form %}
+{% include "components/newsletter.html" with newsletter_form=newsletter_form %}
 
 {% endblock content %}
 
@@ -70,8 +63,8 @@
     "@type": "WebSite",
     "name": "Django Jobs",
     "about": "Job Board",
-    "description": "Best jobs for best Django Developers!",
-    "abstract": "Best jobs for best Django Developers!",
+    "description": "Django jobs for developers who want to work with Django.",
+    "abstract": "Django jobs for developers who want to work with Django.",
     "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}/jobs/",
     "author": {

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -12,7 +12,6 @@
     <meta property="og:title" content="{{ object.title }} @ {% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}" />
     <meta property="og:description" content="{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %} is looking for a {{ object.title }}" />
     <meta property="og:image" content="{{ og_image }}" />
-    <meta property="og:image" content="{{ job.company_logo.build_url }}" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@rasulkireev" />
@@ -23,78 +22,106 @@
 {% endblock meta %}
 
 {% block content %}
-    <p class="mt-4 text-blue-700">
-        ←
-        <a href="{% url 'jobs' %}">back to all jobs</a>
-    </p>
-    <div class="mx-auto my-10 max-w-3xl">
-        <div class="flex flex-col items-center mt-10 prose md:mx-auto lg:prose-lg">
-            <div class="flex-shrink-0">
-              {% if object.company.logo %}
-                <img class="w-24 h-24 rounded-full"
-                      src="{% get_media_prefix %}{{ object.company.logo }}"
-                      alt="{{ object.company }} Logo"/>
-              {% elif object.company_logo %}
-                <img class="w-24 h-24 rounded-full"
-                    src="{{ job.company_logo.build_url }}"
-                    alt="{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}" />
+<section class="bw-page-hero pb-10">
+  <div class="bw-container">
+    <a href="{% url 'jobs' %}" class="inline-flex items-center gap-2 text-sm font-black text-[var(--bw-primary-dark)]">
+      <i class="las la-arrow-left" aria-hidden="true"></i>
+      All jobs
+    </a>
+    <div class="mt-8 grid gap-8 lg:grid-cols-[1fr_20rem] lg:items-start">
+      <div>
+        <div class="flex items-center gap-4">
+          <span class="relative flex h-16 w-16 items-center justify-center overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)] text-2xl font-black text-[var(--bw-primary-dark)]">
+            <span aria-hidden="true">
+              {% if object.company.name %}
+                {{ object.company.name|first }}
+              {% elif object.company_name %}
+                {{ object.company_name|first }}
+              {% else %}
+                D
               {% endif %}
-            </div>
-            <h1 class="text-center">
-                {{ object.title }} @
-                {% if object.company_name %}
-                  <a href="{{ object.company.project.get_absolute_url }}">
-                      {% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}
-                  </a>
-                {% elif object.company_name %}
-                  <span>{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}</span>
-                {% endif %}
-            </h1>
-        </div>
-        <div class="flex justify-center mt-10">
-            <a class="inline-flex items-center px-6 py-3 text-xl font-light text-white bg-green-600 rounded-full border border-transparent border-solid shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-               href="{{ object.listing_url }}?utm_source={{ request.get_host }}&ref={{ request.get_host }}"
-               target="_blank">
-                Apply for this position
-            </a>
-        </div>
-        <div class="py-6 my-10 w-full border-t border-b border-gray-300 border-solid-2">
-            {% if object.location %}
-                <p class="text-lg text-gray-800">
-                    Location:
-                    <b>
-                    {{ object.location }}
-                    </b>
-                </p>
+            </span>
+            {% if object.company.logo %}
+              <img class="absolute inset-0 h-full w-full object-cover"
+                   src="{% get_media_prefix %}{{ object.company.logo }}"
+                   alt="{{ object.company }} Logo"
+                   onerror="this.style.display='none'" />
+            {% elif company_logo_url %}
+              <img class="absolute inset-0 h-full w-full object-cover"
+                   src="{{ company_logo_url }}"
+                   alt="{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}"
+                   onerror="this.style.display='none'" />
             {% endif %}
-            {% if object.min_yearly_salary %}
-                <p class="text-lg text-gray-800">
-                    Salary:
-                    <b>
-                    ${{ object.min_yearly_salary | intcomma }} - ${{ object.max_yearly_salary | intcomma }}
-                    </b>
-                </p>
-            {% endif %}
-            <p class="text-lg text-gray-800">
-                Job Posted: <b>{{ object.created_datetime|timesince }} ago</b>
-            </p>
-        </div>
-        <div class="prose md:prose-lg">
-            {% if object.description %}
-                {{ object.description | markdown | safe }}
+          </span>
+          <p class="font-black bw-muted">
+            {% if object.company %}
+              {{ object.company.name }}
             {% else %}
-                There is no decription
+              {{ object.company_name }}
             {% endif %}
+          </p>
         </div>
-        <div class="flex justify-center mt-10">
-            <a class="inline-flex items-center px-6 py-3 text-xl font-light text-white bg-green-600 rounded-full border border-transparent border-solid shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-               href="{{ object.listing_url }}?utm_source={{ request.get_host }}&ref={{ request.get_host }}"
-               target="_blank">
-                Apply for this position
-            </a>
-        </div>
+        <h1 class="bw-heading-lg mt-6">{{ object.title }}</h1>
+      </div>
+
+      <aside class="bw-surface p-4">
+        <a class="bw-button bw-button-primary w-full"
+           href="{{ object.listing_url }}?utm_source={{ request.get_host }}&ref={{ request.get_host }}"
+           target="_blank"
+           rel="noopener">
+          Apply for this role
+          <i class="las la-external-link-alt" aria-hidden="true"></i>
+        </a>
+        <dl class="mt-5 grid gap-3 text-sm">
+          {% if object.location %}
+            <div class="rounded-md bg-[var(--bw-surface-raised)] p-3">
+              <dt class="font-black text-[var(--bw-ink)]">Location</dt>
+              <dd class="mt-1 bw-muted">{{ object.location }}</dd>
+            </div>
+          {% endif %}
+          {% if object.min_yearly_salary %}
+            <div class="rounded-md bg-[var(--bw-surface-raised)] p-3">
+              <dt class="font-black text-[var(--bw-ink)]">Salary</dt>
+              <dd class="mt-1 bw-muted">${{ object.min_yearly_salary | intcomma }}{% if object.max_yearly_salary %} - ${{ object.max_yearly_salary | intcomma }}{% endif %}</dd>
+            </div>
+          {% endif %}
+          <div class="rounded-md bg-[var(--bw-surface-raised)] p-3">
+            <dt class="font-black text-[var(--bw-ink)]">Posted</dt>
+            <dd class="mt-1 bw-muted">{{ object.created_datetime|timesince }} ago</dd>
+          </div>
+        </dl>
+      </aside>
     </div>
+  </div>
+</section>
+
+<section class="pb-16">
+  <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
+    <article class="bw-surface p-5 sm:p-8">
+      <div class="bw-prose prose max-w-none md:prose-lg">
+        {% if object.description %}
+          {{ object.description | markdown | safe }}
+        {% else %}
+          <p>There is no description for this role yet.</p>
+        {% endif %}
+      </div>
+    </article>
+    <aside class="lg:sticky lg:top-24 lg:self-start">
+      <div class="bw-surface p-5">
+        <h2 class="text-xl font-black">Interested?</h2>
+        <p class="mt-2 text-sm leading-6 bw-muted">Apply on the company site. Built with Django adds tracking params so teams know the community sent you.</p>
+        <a class="bw-button bw-button-primary mt-5 w-full"
+           href="{{ object.listing_url }}?utm_source={{ request.get_host }}&ref={{ request.get_host }}"
+           target="_blank"
+           rel="noopener">
+          Apply now
+        </a>
+      </div>
+    </aside>
+  </div>
+</section>
 {% endblock content %}
+
 {% block schema %}
     <script type="application/ld+json">
 {

--- a/templates/jobs/post-job.html
+++ b/templates/jobs/post-job.html
@@ -1,97 +1,91 @@
 {% extends "base.html" %}
 {% load static %}
+{% load widget_tweaks %}
 
 {% block meta %}
-    <title>Built with Django</title>
-    <meta name="description" content="Collection of cool projects people built with Django" />
+    <title>Post a Django Job | Built with Django</title>
+    <meta name="description" content="Post a Django job for the Built with Django community." />
     <link rel="canonical" href="https://{{ request.get_host }}/jobs/new" />
-    <meta property="og:title" content="Built with Django" />
+    <meta property="og:title" content="Post a Django Job | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/jobs/new" />
-    <meta property="og:description" content="Collection of cool projects people built with Django" />
+    <meta property="og:description" content="Post a Django job for the Built with Django community." />
     <meta property="og:image" content="{% static 'vendors/images/logo.png' %}" />
     <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Built with Django" />
-    <meta name="twitter:description" content="Collection of cool projects people built with Django" />
+    <meta name="twitter:site" content="@builtwithdjango" />
+    <meta name="twitter:title" content="Post a Django Job | Built with Django" />
+    <meta name="twitter:description" content="Post a Django job for the Built with Django community." />
     <meta name="twitter:image" content="{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
-    <div class="w-auto mx-auto mt-10 lg:w-1/3">
-        <div data-controller="loading" class="p-8 mb-6 bg-white border-t-8 border-green-500 rounded-lg shadow-lg">
-            <div class="prose-sm prose">
-                <h1>Post a Job</h1>
-                <p>
-                    It is my intention to make this form super simple. I will fill out all
-                    the necessary info based on the job listing URL you will provide (company logo, description, location, etc.)
-                </p>
-            </div>
-            <form name="form" class="my-4" method="post" enctype="multipart/form-data">
-                {% csrf_token %}
-                {{ form.non_field_errors }}
-                <div class="mb-4">
-                    {{ form.title.errors }}
-                    <label class="block text-sm font-medium text-gray-700" for="{{ form.title.id_for_label }}">
-                        Title
-                    </label>
-                    {{ form.title }}
-                </div>
-                <div class="mb-4">
-                    {{ form.company_name.errors }}
-                    <label class="block text-sm font-medium text-gray-700" for="{{ form.company_name.id_for_label }}">
-                        Company Name
-                    </label>
-                    {{ form.company_name }}
-                </div>
-                <div class="mb-4">
-                    {{ form.listing_url.errors }}
-                    <label class="block text-sm font-medium text-gray-700" for="{{ form.listing_url.id_for_label }}">
-                        Job Listing URL
-                    </label>
-                    {{ form.listing_url }}
-                </div>
-                <div class="mb-4">
-                    {{ form.email.errors }}
-                    <label class="block text-sm font-medium text-gray-700" for="{{ form.email.id_for_label }}">
-                        Your Email (will not be shown)
-                    </label>
-                    {{ form.email }}
-                </div>
-                <div class="mb-4">
-                    {{ form.min_yearly_salary.errors }}
-                    <label class="block text-sm font-medium text-gray-700"
-                           for="{{ form.min_yearly_salary.id_for_label }}">
-                        Min Yearly Salary in USD (optional)
-                    </label>
-                    {{ form.min_yearly_salary }}
-                </div>
-                <div class="mb-4">
-                    {{ form.max_yearly_salary.errors }}
-                    <label class="block text-sm font-medium text-gray-700"
-                           for="{{ form.max_yearly_salary.id_for_label }}">
-                        Max Yearly Salary in USD (optional)
-                    </label>
-                    {{ form.max_yearly_salary }}
-                </div>
+<section class="bw-page-hero pb-10">
+  <div class="bw-container">
+    <p class="bw-kicker">Reach Django developers</p>
+    <h1 class="bw-heading-lg mt-3">Post a Django job</h1>
+    <p class="bw-lede mt-5">Share the core role details. The listing URL lets us fill in the rest and send people to your canonical job post.</p>
+  </div>
+</section>
 
-                <button
-                  data-action="click->loading#load"
-                  data-loading-target="button"
-                  class="flex flex-row px-4 py-2 font-bold text-white bg-green-500 rounded hover:bg-green-300"
-                  type="submit"
-                >
-                  <div data-loading-target="loader" class="hidden" role="status">
-                      <svg aria-hidden="true" class="w-6 h-6 mr-2 text-white animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
-                          <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
-                          <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
-                      </svg>
-                      <span class="sr-only">Loading...</span>
-                  </div>
-                  <div>
-                    Submit
-                  </div>
-                </button>
-            </form>
+<section class="pb-16">
+  <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,42rem)_1fr]">
+    <div data-controller="loading" class="bw-surface p-5 sm:p-8">
+      <form name="form" class="grid gap-5" method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ form.non_field_errors }}
+        <div>
+          {{ form.title.errors }}
+          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.title.id_for_label }}">Role title</label>
+          {% render_field form.title class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="Senior Django Engineer" %}
         </div>
+        <div>
+          {{ form.company_name.errors }}
+          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.company_name.id_for_label }}">Company name</label>
+          {% render_field form.company_name class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="Acme Studio" %}
+        </div>
+        <div>
+          {{ form.listing_url.errors }}
+          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.listing_url.id_for_label }}">Job listing URL</label>
+          {% render_field form.listing_url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://example.com/jobs/django-engineer" %}
+        </div>
+        <div>
+          {{ form.email.errors }}
+          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.email.id_for_label }}">Your email</label>
+          {% render_field form.email class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="hiring@example.com" %}
+          <p class="mt-2 text-sm bw-muted">Only used to contact you about this listing.</p>
+        </div>
+        <div class="grid gap-5 sm:grid-cols-2">
+          <div>
+            {{ form.min_yearly_salary.errors }}
+            <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.min_yearly_salary.id_for_label }}">Min salary, USD</label>
+            {% render_field form.min_yearly_salary class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="120000" %}
+          </div>
+          <div>
+            {{ form.max_yearly_salary.errors }}
+            <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.max_yearly_salary.id_for_label }}">Max salary, USD</label>
+            {% render_field form.max_yearly_salary class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="180000" %}
+          </div>
+        </div>
+        <button data-action="click->loading#load" data-loading-target="button" class="bw-button bw-button-primary justify-self-start" type="submit">
+          <span data-loading-target="loader" class="hidden" role="status">
+            <svg aria-hidden="true" class="h-5 w-5 animate-spin text-[oklch(98%_0.01_118)]" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908Z" fill="currentColor" opacity="0.28"/>
+              <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentColor"/>
+            </svg>
+            <span class="sr-only">Submitting job...</span>
+          </span>
+          Post job
+        </button>
+      </form>
     </div>
+
+    <aside class="bw-surface self-start p-5">
+      <h2 class="text-xl font-black">Why post here?</h2>
+      <ul class="mt-4 grid gap-3 text-sm leading-6 bw-muted">
+        <li><strong class="text-[var(--bw-ink)]">Django-specific audience.</strong> Reach people who already care about this stack.</li>
+        <li><strong class="text-[var(--bw-ink)]">Simple submission.</strong> The listing URL keeps the source of truth on your site.</li>
+        <li><strong class="text-[var(--bw-ink)]">Community context.</strong> Jobs sit alongside projects, guides, and developer profiles.</li>
+      </ul>
+    </aside>
+  </div>
+</section>
 {% endblock content %}

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -24,6 +24,10 @@
     </div>
 
     <div class="bw-hero-showcase">
+      <div class="bw-hero-showcase__header">
+        <p class="bw-hero-showcase__label">Start with the community</p>
+        <p class="bw-hero-showcase__note">Pick a path into projects, guides, people, or Django work.</p>
+      </div>
       <div class="grid gap-3 sm:grid-cols-2">
         {% if projects %}
           {% for project in projects|slice:":4" %}
@@ -48,7 +52,7 @@
             </a>
           {% endfor %}
         {% else %}
-          <a href="{% url 'projects' %}" class="bw-hero-placeholder sm:translate-y-6">
+          <a href="{% url 'projects' %}" class="bw-hero-placeholder">
             <span>
               <span class="bw-menu-icon"><i class="las la-window-restore" aria-hidden="true"></i></span>
               <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Project gallery</span>
@@ -81,7 +85,7 @@
               <i class="las la-arrow-right" aria-hidden="true"></i>
             </span>
           </a>
-          <a href="{% url 'jobs' %}" class="bw-hero-placeholder sm:-translate-y-6">
+          <a href="{% url 'jobs' %}" class="bw-hero-placeholder">
             <span>
               <span class="bw-menu-icon"><i class="las la-bullhorn" aria-hidden="true"></i></span>
               <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Community signals</span>

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -48,26 +48,50 @@
             </a>
           {% endfor %}
         {% else %}
-          <div class="bw-hero-placeholder sm:translate-y-6">
-            <span class="bw-menu-icon"><i class="las la-window-restore" aria-hidden="true"></i></span>
-            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Project gallery</p>
-            <p class="mt-2 text-sm leading-6 bw-muted">A living shelf of Django apps, tools, and experiments.</p>
-          </div>
-          <div class="bw-hero-placeholder">
-            <span class="bw-menu-icon"><i class="las la-book-reader" aria-hidden="true"></i></span>
-            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Practical guides</p>
-            <p class="mt-2 text-sm leading-6 bw-muted">Short paths from idea to working Django feature.</p>
-          </div>
-          <div class="bw-hero-placeholder">
-            <span class="bw-menu-icon"><i class="las la-users" aria-hidden="true"></i></span>
-            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Builder profiles</p>
-            <p class="mt-2 text-sm leading-6 bw-muted">People, makers, and teams shipping in public.</p>
-          </div>
-          <div class="bw-hero-placeholder sm:-translate-y-6">
-            <span class="bw-menu-icon"><i class="las la-bullhorn" aria-hidden="true"></i></span>
-            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Community signals</p>
-            <p class="mt-2 text-sm leading-6 bw-muted">Jobs, launches, sponsorships, and useful resources.</p>
-          </div>
+          <a href="{% url 'projects' %}" class="bw-hero-placeholder sm:translate-y-6">
+            <span>
+              <span class="bw-menu-icon"><i class="las la-window-restore" aria-hidden="true"></i></span>
+              <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Project gallery</span>
+              <span class="mt-2 block text-sm leading-6 bw-muted">A living shelf of Django apps, tools, and experiments.</span>
+            </span>
+            <span class="bw-hero-placeholder__action">
+              Browse projects
+              <i class="las la-arrow-right" aria-hidden="true"></i>
+            </span>
+          </a>
+          <a href="{% url 'blog' %}" class="bw-hero-placeholder">
+            <span>
+              <span class="bw-menu-icon"><i class="las la-book-reader" aria-hidden="true"></i></span>
+              <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Practical guides</span>
+              <span class="mt-2 block text-sm leading-6 bw-muted">Short paths from idea to working Django feature.</span>
+            </span>
+            <span class="bw-hero-placeholder__action">
+              Read guides
+              <i class="las la-arrow-right" aria-hidden="true"></i>
+            </span>
+          </a>
+          <a href="{% url 'developers' %}" class="bw-hero-placeholder">
+            <span>
+              <span class="bw-menu-icon"><i class="las la-users" aria-hidden="true"></i></span>
+              <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Builder profiles</span>
+              <span class="mt-2 block text-sm leading-6 bw-muted">People, makers, and teams shipping in public.</span>
+            </span>
+            <span class="bw-hero-placeholder__action">
+              Meet developers
+              <i class="las la-arrow-right" aria-hidden="true"></i>
+            </span>
+          </a>
+          <a href="{% url 'jobs' %}" class="bw-hero-placeholder sm:-translate-y-6">
+            <span>
+              <span class="bw-menu-icon"><i class="las la-bullhorn" aria-hidden="true"></i></span>
+              <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Community signals</span>
+              <span class="mt-2 block text-sm leading-6 bw-muted">Jobs, launches, sponsorships, and useful resources.</span>
+            </span>
+            <span class="bw-hero-placeholder__action">
+              Browse jobs
+              <i class="las la-arrow-right" aria-hidden="true"></i>
+            </span>
+          </a>
         {% endif %}
       </div>
     </div>

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -1,185 +1,214 @@
 {% extends "base.html" %}
 {% load static %}
-{% load cloudinary %}
 {% load widget_tweaks %}
 
 {% block content %}
-<div class="flex flex-col justify-between items-center mt-10 mb-20 bg-white md:flex-row sm:mt-12 md:mt-16 xl:mt-28 lg:mt-20">
-    <div class="mb-20 md:mb-0 sm:text-center lg:text-left">
-      <h1 class="text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">
-        <span class="md:block xl:inline">Learn</span>
-        <span class="text-green-600 md:block xl:inline">Django</span>
-      </h1>
-      <p class="mt-3 text-base text-gray-500 sm:mt-5 sm:text-lg sm:max-w-xl sm:mx-auto md:mt-5 md:text-xl lg:mx-0">Learn to bring your project and business ideas to life with Django. Get inspired by others.</p>
-      <div class="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-start">
-        <div class="mt-3 sm:mt-0">
-          <a href="{% url 'blog' %}" class="flex justify-center items-center px-8 py-3 w-full text-base font-medium text-green-700 bg-green-100 rounded-md border border-transparent hover:bg-green-200 md:py-4 md:text-lg md:px-10"> Explore Lessons </a>
-        </div>
-        <div class="mt-3 sm:mt-0 sm:ml-3">
-          <a href="{% url 'projects' %}" class="flex justify-center items-center px-8 py-3 w-full text-base font-medium text-green-700 bg-green-100 rounded-md border border-transparent hover:bg-green-200 md:py-4 md:text-lg md:px-10"> Explore Projects </a>
-        </div>
+<section class="bw-section">
+  <div class="bw-container-wide grid items-center gap-10 lg:grid-cols-[0.95fr_1.05fr]">
+    <div>
+      <p class="bw-kicker">
+        <i class="las la-seedling" aria-hidden="true"></i>
+        Community showcase
+      </p>
+      <h1 class="bw-heading-xl mt-5">Built with Django</h1>
+      <p class="bw-lede mt-6">
+        See what people are shipping with Django, learn from practical guides, find Django work, and discover builders from the community.
+      </p>
+      <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+        <a href="{% url 'projects' %}" class="bw-button bw-button-primary">
+          Explore projects
+          <i class="las la-arrow-right" aria-hidden="true"></i>
+        </a>
+        <a href="{% url 'blog' %}" class="bw-button bw-button-secondary">Read guides</a>
       </div>
     </div>
 
-  <div>
-    <svg xmlns="http://www.w3.org/2000/svg" class="object-cover w-full h-56 sm:h-72" data-name="Layer 1" width="717.67003" height="453.96431" viewBox="0 0 717.67003 453.96431" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <path d="M527.60118,309.43775a3.82674,3.82674,0,0,1-4.314,1.25745,5.82854,5.82854,0,0,1-.6787-.24764,28.82552,28.82552,0,0,0-.36725-7.98934,21.36236,21.36236,0,0,1-1.63966,6.57017,8.91079,8.91079,0,0,1-1.75993-2.51274,22.42528,22.42528,0,0,1-1.60307-6.0463c-1.20439-7.0881-2.39281-14.46206-.42756-21.389,2.87885-10.119,11.95723-17.39344,15.74893-27.21118l1.86811-1.677c3.19777,5.44543,3.33934,12.212,2.03576,18.38674-1.29657,6.187-3.90949,11.99371-5.97512,17.96023s-3.61313,12.31309-2.6548,18.55641C528.05421,306.56558,528.39023,308.18131,527.60118,309.43775Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <polygon points="230.469 157.098 218.295 212.779 271.469 230.098 263.65 157.098 230.469 157.098" fill="#ffb6b6"/>
-      <path d="M861.31381,690.55887h24.09571V580.09012A107.65288,107.65288,0,0,0,777.87876,472.55887H553.94028A107.65288,107.65288,0,0,0,446.40952,580.09012V690.55887h24.0957V615.09012A108.65356,108.65356,0,0,1,579.036,506.55887H752.78305A108.65356,108.65356,0,0,1,861.31381,615.09012Z" transform="translate(-255.61478 -237.96119)" fill="#e6e6e6"/>
-      <path d="M568.509,632.7673l-25.68043-7.775a88.4837,88.4837,0,0,1-2.50888-20.963,8.39912,8.39912,0,0,1,13.815-6.35513c13.77338,11.81381,33.94829,18.11782,46.96791,31.58028a52.07341,52.07341,0,0,1,13.888,42.946l5.621,18.18083a87.2586,87.2586,0,0,1-63.97667-35.28461,84.28716,84.28716,0,0,1-10.12173-18.565C557.40487,635.29616,568.509,632.7673,568.509,632.7673Z" transform="translate(-255.61478 -237.96119)" fill="#f2f2f2"/>
-      <path d="M635.438,662.5404l13.09791-3.96554q.02533-.10428.0502-.2087a8.409,8.409,0,0,0-12.48265-9.09359c-5.94563,3.532-12.54779,6.57335-17.28929,11.47613a26.55922,26.55922,0,0,0-7.08337,21.904l-2.86689,9.27285a44.50485,44.50485,0,0,0,32.6303-17.99636,42.98864,42.98864,0,0,0,5.16243-9.46881C641.10146,663.83021,635.438,662.5404,635.438,662.5404Z" transform="translate(-255.61478 -237.96119)" fill="#f2f2f2"/>
-      <path d="M741.46337,391.0911H690.45778a2.72143,2.72143,0,0,0-2.71731,2.72433v80.57381h56.44722V393.81543A2.7229,2.7229,0,0,0,741.46337,391.0911Zm-25.3312,45.78106a6.05117,6.05117,0,0,1-6.02292-6.02289v-9.29349a6.02291,6.02291,0,0,1,12.04581,0v9.29349a6.05109,6.05109,0,0,1-6.02289,6.02289Z" transform="translate(-255.61478 -237.96119)" fill="#3f3d56"/>
-      <path d="M825.92405,265.34656H607.895a7.07769,7.07769,0,0,0-7.06643,7.06638V419.53985a7.07318,7.07318,0,0,0,7.06643,7.06638h218.029a7.07318,7.07318,0,0,0,7.06643-7.06638V272.41294A7.07769,7.07769,0,0,0,825.92405,265.34656Z" transform="translate(-255.61478 -237.96119)" fill="#3f3d56"/>
-      <path d="M824.10413,270.4505H609.71662a3.78733,3.78733,0,0,0-3.7791,3.787V417.71769a3.78562,3.78562,0,0,0,3.7791,3.7791H824.10413a3.78562,3.78562,0,0,0,3.7791-3.7791V274.23747A3.78733,3.78733,0,0,0,824.10413,270.4505Z" transform="translate(-255.61478 -237.96119)" fill="#fff"/>
-      <path d="M687.56538,471.812v7.77377a1.52285,1.52285,0,0,0,1.51976,1.51972h53.75792a1.52739,1.52739,0,0,0,1.51972-1.51972V471.812Z" transform="translate(-255.61478 -237.96119)" fill="#3f3d56"/>
-      <path d="M782.34508,483.81055H654.7962a2.34634,2.34634,0,0,1-2.296-2.82966l1.97916-9.39973a2.35648,2.35648,0,0,1,2.29564-1.86291H780.36631a2.35648,2.35648,0,0,1,2.29565,1.86291l1.97915,9.39973a2.34634,2.34634,0,0,1-2.296,2.82966Z" transform="translate(-255.61478 -237.96119)" fill="#3f3d56"/>
-      <rect x="402.06594" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="409.92271" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="417.77947" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="425.63623" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="433.493" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="441.34976" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="449.20652" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="457.06329" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="464.92005" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="472.77682" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="480.63358" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="488.49034" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="496.34711" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="504.20387" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="512.06064" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="519.9174" y="233.44964" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="401.9731" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="409.82987" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="417.68663" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="425.54339" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="433.40016" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="441.25692" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="449.11369" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="456.97045" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="464.82721" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="472.68398" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="480.54074" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="488.39751" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="496.25427" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="504.11103" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="511.9678" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="519.82456" y="237.37802" width="3.92838" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <rect x="439.68557" y="242.09208" width="31.42706" height="2.35703" rx="0.48819" fill="#e6e6e6"/>
-      <path d="M792.13789,306.46885v75.52a19.07267,19.07267,0,0,1-19.07,19.07h-94.52a19.08094,19.08094,0,0,1-17.51-11.49,17.9844,17.9844,0,0,1-1.13-3.51,17.36726,17.36726,0,0,0,6.3,1.17h94.52a17.60458,17.60458,0,0,0,17.58-17.58v-75.52a17.36787,17.36787,0,0,0-1.17-6.3,17.98805,17.98805,0,0,1,3.51,1.13A19.08093,19.08093,0,0,1,792.13789,306.46885Z" transform="translate(-255.61478 -237.96119)" fill="#f2f2f2"/>
-      <polygon points="183.897 368.973 174.522 374.778 146.903 340.828 160.739 332.262 183.897 368.973" fill="#ffb6b6"/>
-      <path d="M447.60543,619.06017l-7.54133,3.36653-4.5245-6.519-.26914,8.65893-20.0014,8.92883a4.9238,4.9238,0,0,1-6.21365-7.05552l11.04809-18.1615-3.21326-7.198,17.248-6.49708Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <path d="M413.24955,600.40319l15.8338-15.34432c-11.7637-29.02906-12.70376-47.02215-29.01206-82.13088,38.693,7.91409,66.35622,7.433,98.35619.33742,10.83323-2.3646,38.78551-23.95594,36.48735-35.02685q-.16112-.77624-.3807-1.538c-3.43482-11.7114-1.01609-29.64574-8.45078-42.64173-13.75489-5.18582-34.65268,12.32556-51,23-7.88255,5.14713-2.11233,12.1612-8,14l-22.569,7.32613-55.3725-8.943a20.51148,20.51148,0,0,0-23.37624,17.35929q-.14055.9018-.20361,1.81341c2.54779,14.10343,5.20366,27.83673,8.063,40.87333.923,4.20807-.6352,12.27539,2.8357,12.39545s2.07272,8.46395,3.15368,12.54322C386.2692,569.54028,390.47748,581.69383,413.24955,600.40319Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <polygon points="127.329 429.745 117.562 424.647 133.015 383.711 147.43 391.235 127.329 429.745" fill="#ffb6b6"/>
-      <path d="M381.31592,637.14483l15.6612,10.78289c19.19456-27.75961,31.65753-64.854,40.93905-106.36,36.13851-15.76472,67.76063-33.80089,89.79648-57.99314a20.9147,20.9147,0,0,0-1.20931-29.095q-.5784-.5422-1.196-1.03885c-9.54471-7.60285-30.74283-3.22816-44.29181-9.58275l-24.204,33.49961,2.78211,7.80252-8.41994,4.099-7.1092,3.46086-8.13813,3.96175L409.24825,509.669a20.4837,20.4837,0,0,0-9.089,27.62925q.40434.81821.87758,1.59992l-9.908,49.36015s2.72631,8.59307-1.56348,7.789-1.95215,9.72532-1.95215,9.72532Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <path d="M377.029,690.26656l-7.32146-3.82115,2.30077-7.5944-6.95466,5.16548-19.41828-10.13462a4.9238,4.9238,0,0,1,1.67253-9.25162l21.09632-2.61639,3.64718-6.98813,15.80243,9.48616Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <path d="M590.50644,475.66465l-11.42309-27.60578-9,5,5.43524,28.0821a10.0012,10.0012,0,1,0,14.98785-5.47632Z" transform="translate(-255.61478 -237.96119)" fill="#ffb6b6"/>
-      <path d="M398.82273,257.36811l17.381,24.29955,7.633-6.90918L412.18,248.63825a10.0012,10.0012,0,1,0-13.35723,8.72986Z" transform="translate(-255.61478 -237.96119)" fill="#ffb6b6"/>
-      <path d="M477.31168,411.38205c-11.2735,17.48627,30.02795,55.58585,51.77167,46.67682,3.80743-1.56,16.90438-6.71266,7.95219-13.85633s1.03792.851,1.274-3.79932c.15787-3.109-2.24924-9.9292.26227-9.63677s3.953-6.97133-1.51673-8.82157a10.61794,10.61794,0,0,1-7-9c-.523-19.16651,5.96782-39.17735,5.96782-39.17735l26.49793,67.73493s-.19573,11.71851,3.18337,8.13746,3.13322,8.00923,3.13322,8.00923,5.02458,3.50661,2.13523,5.45816,3.11066,7.95156,3.11066,7.95156l14-1s-.21919-10.4-2.6096-12.7-1.21623-5.919-1.21623-5.919-4.92825-4.58417-2.05121-9.98259-20.951-101.96148-20.951-101.96148a25.7199,25.7199,0,0,0-18.366-19.62039l-15.12093-4.16334-2.685-10.6532H503.792l-3.70866,7-34-3s-33.64257-30.60991-32-33-3.57255-7.98576-3.57255-7.98576-4.45387-1.45771-1.94066-2.236-2.23723-2.57768-2.23723-2.57768-4.39964-1.1561-2.3246-2.67834-6.925-2.52224-6.925-2.52224l-11.67717,9.52756,2.3601,4.00191s-1.439,5.44938.439,3.46,2.23156,3.78393,2.23156,3.78393.95909,6.32194,6.64648,8.22664,10,20,10,20l48,40c-7.31055,8.39115-5.5705,17.166.90564,26.14173Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/><circle cx="258.34259" cy="36.96382" r="23.0557" fill="#ffb6b6"/>
-      <path d="M534.08335,268.05887c-.59.17-9.25,1.3-13,2-3.68.69-4.32-4-7.33-3.12a.1266.1266,0,0,0-.01-.06,28.34378,28.34378,0,0,0-2.37-7.17,21.17806,21.17806,0,0,1,.17005,6.6.98419.98419,0,0,1-.02.17c-.01.1-.03.19-.04.29-3.18-1.4-5.2-.15-7.4.29-2.46.49-4.38,1.57-3,10,2.83,17.34,17.55,23.53,15,35-.5,2.27-1.76,5.11-3.34,5.82a28.34378,28.34378,0,0,0-2.37-7.17,21.17806,21.17806,0,0,1,.17005,6.6c-2.45-2.65-4.22-11.91-12.46-19.25-2.03-1.8-12.2-12.48-13.42-15a32.13615,32.13615,0,0,1,.54,6.11,29.41586,29.41586,0,0,1-.28,4.1,1.15145,1.15145,0,0,1-.03.26c-.01.16-.04.3-.06.45-.02.17-.05.33-.08.5-3.33-.48-6.28-1.06-7.67-2.42-6.76-6.58,1.49-19.4,6-31,6.45-16.61,25.18-18.82,27-19,8.02-.81,21.57.91,26,10C539.18332,258.42887,537.20334,267.15885,534.08335,268.05887Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <path d="M485.46837,271.80814l16.70111-25.98028a25.61246,25.61246,0,0,0-13.18811-3.4596,16.41918,16.41918,0,0,0-12.10913,5.71143c-3.41095,4.2392-3.99622,10.23181-2.7182,15.52069C474.59538,265.427,483,259,481,262c-1.64185,2.34882-4.3266,12.2215-5,15-1.08368,4.4718-4.06343,9.06211-1.40907,12.82053,3.13885,4.44446,8.74,6.65363,14.17651,6.878s10.7876-1.28223,15.95416-2.98871Z" transform="translate(-255.61478 -237.96119)" fill="#2f2e41"/>
-      <path d="M491.88559,270.78348a1.00011,1.00011,0,0,1-.27295-1.96191c.26221-.43262.15479-2.25342.06836-3.72461-.32519-5.52393-.86963-14.769,8.106-21.00977a.99976.99976,0,0,1,1.1416,1.6416c-8.05469,5.60108-7.57129,13.81543-7.251,19.25049.18262,3.10742.315,5.352-1.56982,5.7793A.99351.99351,0,0,1,491.88559,270.78348Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M255.61478,689.91176a1.18648,1.18648,0,0,0,1.18292,1.19H972.09481a1.19,1.19,0,0,0,0-2.38h-715.29a1.18649,1.18649,0,0,0-1.19,1.183Z" transform="translate(-255.61478 -237.96119)" fill="#ccc"/>
-      <path d="M698.14954,332.81065H683.01746a1.51321,1.51321,0,0,1,0-3.02642h15.13208a1.51321,1.51321,0,0,1,0,3.02642Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M725.38727,332.81065H710.2552a1.51321,1.51321,0,1,1,0-3.02642h15.13207a1.51321,1.51321,0,1,1,0,3.02642Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M739.00614,344.91631H723.87407a1.51321,1.51321,0,1,1,0-3.02642h15.13207a1.51321,1.51321,0,1,1,0,3.02642Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M711.8519,344.91631H683.01746a1.51321,1.51321,0,0,1,0-3.02642H711.8519a1.51321,1.51321,0,0,1,0,3.02642Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M766.32737,332.81065H737.49293a1.51321,1.51321,0,0,1,0-3.02642h28.83444a1.51321,1.51321,0,1,1,0,3.02642Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M708.50929,309.88668H679.67486a1.51321,1.51321,0,1,1,0-3.02641h28.83443a1.5132,1.5132,0,1,1,0,3.02641Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M710.88008,318.72742a1.35512,1.35512,0,0,1-.83239-2.425l7.38326-5.73907a2.71359,2.71359,0,0,0,.328-3.9837l-6.19864-6.7106a1.35508,1.35508,0,1,1,1.99032-1.83946l9.20523,9.96483a1.3553,1.3553,0,0,1-.16344,1.98966l-10.88125,8.45819A1.35141,1.35141,0,0,1,710.88008,318.72742Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M678.21581,318.72742a1.35512,1.35512,0,0,0,.83239-2.425l-7.38326-5.73907a2.71358,2.71358,0,0,1-.328-3.9837l6.19864-6.7106a1.35508,1.35508,0,0,0-1.99032-1.83946l-9.20523,9.96483a1.35531,1.35531,0,0,0,.16343,1.98966l10.88126,8.45819A1.35136,1.35136,0,0,0,678.21581,318.72742Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M723.41551,370.86669H694.58108a1.51321,1.51321,0,0,1,0-3.02642h28.83443a1.51321,1.51321,0,0,1,0,3.02642Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M728.49652,378.35231a1.35512,1.35512,0,0,1-.83239-2.425l7.38326-5.73907a2.71357,2.71357,0,0,0,.328-3.98369l-6.19864-6.71061a1.35508,1.35508,0,0,1,1.99032-1.83946l9.20523,9.96483a1.35531,1.35531,0,0,1-.16343,1.98966l-10.88125,8.4582A1.35146,1.35146,0,0,1,728.49652,378.35231Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M678.21581,378.35231a1.35512,1.35512,0,0,0,.83239-2.425l-7.38326-5.73907a2.71357,2.71357,0,0,1-.328-3.98369l6.19864-6.71061a1.35508,1.35508,0,1,0-1.99032-1.83946l-9.20523,9.96483a1.35531,1.35531,0,0,0,.16343,1.98966l10.88126,8.4582A1.35142,1.35142,0,0,0,678.21581,378.35231Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-      <path d="M680.78914,374.11256l6.06111-13.86516a1.51321,1.51321,0,0,1,2.773,1.21223l-6.06112,13.86515a1.51321,1.51321,0,1,1-2.773-1.21222Z" transform="translate(-255.61478 -237.96119)" fill="#6c63ff"/>
-    </svg>
-  </div>
-</div>
-
-<div class="overflow-hidden my-10 bg-white">
-  <div class="relative px-4 py-12 mx-auto max-w-6xl sm:px-6 lg:px-8">
-    <svg class="absolute top-0 left-full transform -translate-x-1/2 -translate-y-3/4 lg:left-auto lg:right-full lg:translate-x-2/3 lg:translate-y-1/4" width="404" height="784" fill="none" viewBox="0 0 404 784" aria-hidden="true">
-      <defs>
-        <pattern id="8b1b5f72-e944-4457-af67-0c6d15a99f38" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-          <rect x="0" y="0" width="4" height="4" class="text-gray-200" fill="currentColor" />
-        </pattern>
-      </defs>
-      <rect width="404" height="784" fill="url(#8b1b5f72-e944-4457-af67-0c6d15a99f38)" />
-    </svg>
-
-    <div class="relative lg:grid lg:grid-cols-3 lg:gap-x-8">
-      <div class="lg:col-span-1">
-        <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 sm:text-4xl">Latest Django Guides</h2>
+    <div class="bw-hero-showcase">
+      <div class="grid gap-3 sm:grid-cols-2">
+        {% if projects %}
+          {% for project in projects|slice:":4" %}
+            <a href="{% url 'project' project.slug %}" class="group block overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)] shadow-sm">
+              <div class="aspect-[16/10] overflow-hidden bg-[var(--bw-surface-muted)]">
+                {% if project.homepage_screenshot %}
+                  <img
+                    src="{% get_media_prefix %}{{ project.homepage_screenshot }}"
+                    alt="{{ project.title }} screenshot"
+                    class="h-full w-full object-cover object-left-top transition duration-200 group-hover:scale-[1.025]"
+                    loading="{% if forloop.counter <= 2 %}eager{% else %}lazy{% endif %}"
+                    decoding="async"
+                  />
+                {% else %}
+                  <div class="flex h-full items-center justify-center p-6 text-center text-sm font-bold bw-muted">Screenshot coming soon</div>
+                {% endif %}
+              </div>
+              <div class="p-3">
+                <p class="font-black leading-tight text-[var(--bw-ink)]">{{ project.title }}</p>
+                <p class="mt-1 line-clamp-2 text-sm leading-5 bw-muted">{{ project.short_description }}</p>
+              </div>
+            </a>
+          {% endfor %}
+        {% else %}
+          <div class="bw-hero-placeholder sm:translate-y-6">
+            <span class="bw-menu-icon"><i class="las la-window-restore" aria-hidden="true"></i></span>
+            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Project gallery</p>
+            <p class="mt-2 text-sm leading-6 bw-muted">A living shelf of Django apps, tools, and experiments.</p>
+          </div>
+          <div class="bw-hero-placeholder">
+            <span class="bw-menu-icon"><i class="las la-book-reader" aria-hidden="true"></i></span>
+            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Practical guides</p>
+            <p class="mt-2 text-sm leading-6 bw-muted">Short paths from idea to working Django feature.</p>
+          </div>
+          <div class="bw-hero-placeholder">
+            <span class="bw-menu-icon"><i class="las la-users" aria-hidden="true"></i></span>
+            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Builder profiles</p>
+            <p class="mt-2 text-sm leading-6 bw-muted">People, makers, and teams shipping in public.</p>
+          </div>
+          <div class="bw-hero-placeholder sm:-translate-y-6">
+            <span class="bw-menu-icon"><i class="las la-bullhorn" aria-hidden="true"></i></span>
+            <p class="mt-5 text-xl font-black leading-tight text-[var(--bw-ink)]">Community signals</p>
+            <p class="mt-2 text-sm leading-6 bw-muted">Jobs, launches, sponsorships, and useful resources.</p>
+          </div>
+        {% endif %}
       </div>
-      <div class="mt-10 space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:gap-y-10 lg:mt-0 lg:col-span-2">
+    </div>
+  </div>
+
+  <div class="bw-container mt-10">
+    <div class="bw-proof-strip">
+      <div>
+        <p class="font-black text-[var(--bw-ink)]">Real products</p>
+        <p class="mt-1 text-sm bw-muted">Screenshots and links from the ecosystem.</p>
+      </div>
+      <div>
+        <p class="font-black text-[var(--bw-ink)]">Practical learning</p>
+        <p class="mt-1 text-sm bw-muted">Guides for people building real apps.</p>
+      </div>
+      <div>
+        <p class="font-black text-[var(--bw-ink)]">Community signals</p>
+        <p class="mt-1 text-sm bw-muted">Jobs, makers, developers, and useful tools.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bw-section pt-0">
+  <div class="bw-container">
+    <div class="grid gap-4 md:grid-cols-4">
+      <a href="{% url 'projects' %}" class="bw-card p-5">
+        <span class="bw-menu-icon"><i class="las la-window-restore" aria-hidden="true"></i></span>
+        <h2 class="mt-5 text-2xl font-black leading-tight">Browse projects</h2>
+        <p class="mt-3 text-sm leading-6 bw-muted">Study shipped products, open source apps, internal tools, and indie experiments.</p>
+      </a>
+      <a href="{% url 'blog' %}" class="bw-card p-5">
+        <span class="bw-menu-icon"><i class="las la-book-open" aria-hidden="true"></i></span>
+        <h2 class="mt-5 text-2xl font-black leading-tight">Learn Django</h2>
+        <p class="mt-3 text-sm leading-6 bw-muted">Read focused tutorials and notes that help you build with less guessing.</p>
+      </a>
+      <a href="{% url 'jobs' %}" class="bw-card p-5">
+        <span class="bw-menu-icon"><i class="las la-briefcase" aria-hidden="true"></i></span>
+        <h2 class="mt-5 text-2xl font-black leading-tight">Find Django work</h2>
+        <p class="mt-3 text-sm leading-6 bw-muted">A job board for teams and developers who want Django experience.</p>
+      </a>
+      <a href="{% url 'developers' %}" class="bw-card p-5">
+        <span class="bw-menu-icon"><i class="las la-user-astronaut" aria-hidden="true"></i></span>
+        <h2 class="mt-5 text-2xl font-black leading-tight">Meet developers</h2>
+        <p class="mt-3 text-sm leading-6 bw-muted">Find Django people who are available for contracts, roles, and collaborations.</p>
+      </a>
+    </div>
+  </div>
+</section>
+
+<section class="bw-section bg-[oklch(93.5%_0.022_124_/_0.72)]">
+  <div class="bw-container">
+    <div class="flex flex-col justify-between gap-5 md:flex-row md:items-end">
+      <div>
+        <p class="bw-kicker">Latest showcase</p>
+        <h2 class="bw-heading-lg mt-3">Fresh Django projects</h2>
+      </div>
+      <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent">Submit your project</a>
+    </div>
+    <div class="bw-project-grid mt-8">
+      {% for project in projects %}
+        {% include "components/project-card.html" with site=project %}
+      {% empty %}
+        <div class="bw-empty-state md:col-span-2 lg:col-span-3">
+          <span class="bw-menu-icon"><i class="las la-seedling" aria-hidden="true"></i></span>
+          <h3 class="mt-5 text-2xl font-black text-[var(--bw-ink)]">No projects yet</h3>
+          <p class="mt-2 max-w-xl text-sm leading-6 bw-muted">The showcase is ready for the next Django build. Submit a project to help the community discover what people are shipping.</p>
+          <a href="{% url 'submit_project' %}" class="bw-button bw-button-primary mt-5">Submit a project</a>
+        </div>
+      {% endfor %}
+    </div>
+    <div class="mt-8">
+      <a href="{% url 'projects' %}" class="bw-button bw-button-secondary">View all projects</a>
+    </div>
+  </div>
+</section>
+
+<section class="bw-section">
+  <div class="bw-container grid gap-6 lg:grid-cols-[1fr_0.85fr]">
+    <div>
+      <div class="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <p class="bw-kicker">Guides</p>
+          <h2 class="bw-heading-md mt-3">Learn by building</h2>
+        </div>
+        <a href="{% url 'blog' %}" class="hidden font-bold text-[var(--bw-primary-dark)] md:inline-flex">All guides</a>
+      </div>
+      <div class="grid gap-3 md:grid-cols-2">
         {% for guide in guides %}
-        <a href="{% url 'post' guide.slug %}" class="flex bg-white rounded-md border border-gray-100 shadow group">
-            <div class="flex flex-shrink-0 items-center p-4 bg-gray-100 lg:p-4">
-              <!-- Heroicon name: outline/globe-alt -->
-              <img class="flex-shrink-0 mx-auto w-8 h-8 lg:h-16 lg:w-16"
-                   src="https://res.cloudinary.com/built-with-django/{{ guide.icon }}"
-                   alt="" />
-            </div>
-            <div class="flex flex-col p-4 h-full lg:p-6">
-              <p class="text-base font-medium text-gray-900">{{ guide.title }}</p>
-              <p class="mt-2 text-sm text-gray-500">{{ guide.description | truncatewords:20 }}</p>
-            </div>
-        </a>
-        {% endfor %}
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="overflow-hidden my-10 bg-white">
-  <div class="relative px-4 py-12 mx-auto max-w-6xl sm:px-6 lg:px-8">
-    <svg class="absolute top-0 right-full transform -translate-x-1/2 -translate-y-3/4 lg:left-full lg:right-auto lg:-translate-x-2/3 lg:translate-y-1/4" width="404" height="784" fill="none" viewBox="0 0 404 784" aria-hidden="true">
-      <defs>
-        <pattern id="8b1b5f72-e944-4457-af67-0c6d15a99f38" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-          <rect x="0" y="0" width="4" height="4" class="text-gray-200" fill="currentColor" />
-        </pattern>
-      </defs>
-      <rect width="404" height="784" fill="url(#8b1b5f72-e944-4457-af67-0c6d15a99f38)" />
-    </svg>
-
-    <div class="relative lg:grid lg:grid-cols-3 lg:gap-x-8">
-      <div class="order-last lg:col-span-1">
-        <h2 class="text-3xl font-extrabold tracking-tight text-right text-gray-900 sm:text-4xl">Latest Django Projects</h2>
-        <div class="mt-5 flex justify-end">
-          <a href="{% url 'submit_project' %}" class="inline-flex justify-center items-center px-6 py-3 text-base font-medium text-white bg-green-600 rounded-md border border-transparent hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-            Add Project
-          </a>
-        </div>
-      </div>
-      <div class="mt-10 space-y-10 sm:space-y-0 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:gap-y-10 lg:mt-0 lg:col-span-2">
-        {% for project in projects %}
-        <a
-          href="{% url 'project' project.slug %}"
-          class="
-            flex flex-col justify-start bg-white rounded border-solid
-            {% if project.sponsored %}
-            border-4 border-yellow-500 shadow-2xl
-            {% else %}
-            shadow border-1
+          <a href="{% url 'post' guide.slug %}" class="bw-card flex gap-4 p-4">
+            {% if guide.icon %}
+              <span class="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-[var(--bw-surface-muted)]">
+                <img class="h-9 w-9 object-contain" src="https://res.cloudinary.com/built-with-django/{{ guide.icon }}" alt="" loading="lazy" decoding="async" />
+              </span>
             {% endif %}
-          "
-        >
-          <div class="border-b border-gray-300 border-solid">
-            <!-- Heroicon name: outline/globe-alt -->
-            <img class="object-cover object-left-top w-full h-auto {% if not project.sponsored %}rounded-t{% endif %} border-0"
-            src="{% get_media_prefix %}{{ project.homepage_screenshot }}"
-            alt="{{ project.title }} | Screenshot" />
+            <span>
+              <span class="block font-black leading-snug text-[var(--bw-ink)]">{{ guide.title }}</span>
+              <span class="mt-2 block text-sm leading-6 bw-muted">{{ guide.description | truncatewords:18 }}</span>
+            </span>
+          </a>
+        {% empty %}
+          <div class="bw-empty-state md:col-span-2">
+            <span class="bw-menu-icon"><i class="las la-pen-nib" aria-hidden="true"></i></span>
+            <h3 class="mt-5 text-xl font-black text-[var(--bw-ink)]">Guides are being curated</h3>
+            <p class="mt-2 text-sm leading-6 bw-muted">This area is designed for practical Django walkthroughs and community notes.</p>
           </div>
-          <div class="flex-auto p-4 h-full border-b border-gray-300 border-solid">
-            <p class="text-base font-medium text-gray-900">{{ project.title }}</p>
-            <p class="mt-2 text-sm text-gray-500">{{ project.short_description }}</p>
-          </div>
-        </a>
         {% endfor %}
       </div>
     </div>
+
+    <aside class="bw-card p-5">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <p class="bw-kicker">Jobs</p>
+          <h2 class="mt-3 text-2xl font-black">Django teams are hiring</h2>
+        </div>
+        <a href="{% url 'post_job' %}" class="bw-button bw-button-secondary hidden sm:inline-flex">Post job</a>
+      </div>
+      <div class="mt-5 grid gap-3">
+        {% for job in jobs %}
+          <a href="{{ job.get_absolute_url }}" class="block rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface-raised)] p-4 hover:border-[var(--bw-primary)]">
+            <p class="font-black leading-snug text-[var(--bw-ink)]">{{ job.title }}</p>
+            <p class="mt-1 text-sm bw-muted">
+              {% if job.company.name %}
+                {{ job.company.name }}
+              {% elif job.company_name %}
+                {{ job.company_name }}
+              {% endif %}
+            </p>
+          </a>
+        {% empty %}
+          <p class="rounded-md border border-dashed border-[var(--bw-border)] p-4 text-sm bw-muted">No jobs are live right now.</p>
+        {% endfor %}
+      </div>
+      <div class="mt-5 flex flex-col gap-2 sm:flex-row">
+        <a href="{% url 'jobs' %}" class="bw-button bw-button-primary">Browse jobs</a>
+        <a href="{% url 'post_job' %}" class="bw-button bw-button-secondary sm:hidden">Post job</a>
+      </div>
+    </aside>
   </div>
-</div>
+</section>
 
 {% include "components/newsletter.html" with newsletter_form=newsletter_form %}
 

--- a/templates/projects/all_projects.html
+++ b/templates/projects/all_projects.html
@@ -3,209 +3,139 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Built with Django</title>
-    <meta name="description" content="Collection of cool projects people built with Django" />
+    <title>Django Projects | Built with Django</title>
+    <meta name="description" content="Discover real projects and apps built with Django." />
     <link rel="canonical" href="https://{{ request.get_host }}/projects/" />
-    <meta property="og:title" content="Built with Django" />
+    <meta property="og:title" content="Django Projects | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/projects/" />
-    <meta property="og:description" content="Collection of cool projects people built with Django" />
+    <meta property="og:description" content="Discover real projects and apps built with Django." />
     <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Built with Django" />
-    <meta name="twitter:description" content="Collection of cool projects people built with Django" />
+    <meta name="twitter:site" content="@builtwithdjango" />
+    <meta name="twitter:title" content="Django Projects | Built with Django" />
+    <meta name="twitter:description" content="Discover real projects and apps built with Django." />
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
-
-    <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
-      <div class="mx-auto max-w-2xl text-center">
-        <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Projects</h1>
-        <p class="mt-6 text-lg leading-8 text-gray-600 prose">Inspire and be inspired: discover amazing projects built with Django.</p>
-      </div>
-    </div>
-
+<section class="bw-page-hero">
+  <div class="bw-container grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
     <div>
-        <div class="flex justify-between items-center pb-4 sm:mb-0">
-            <div class="flex justify-start items-center space-x-2">
-
-              <div data-controller="dropdown" class="inline-block relative text-left">
-                  <div>
-                      <button type="button"
-                              data-action="dropdown#toggle click@window->dropdown#hide"
-                              class="inline-flex justify-center px-4 py-3 w-full text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-indigo-500"
-                              id="menu-button"
-                              aria-expanded="true"
-                              aria-haspopup="true">
-                          Filter
-                          <!-- Heroicon name: solid/chevron-down -->
-                          <svg class="-mr-1 ml-2 w-5 h-5"
-                               xmlns="http://www.w3.org/2000/svg"
-                               viewBox="0 0 20 20"
-                               fill="currentColor"
-                               aria-hidden="true">
-                              <path fill-rule="evenodd"
-                                    d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                    clip-rule="evenodd"/>
-                          </svg>
-                      </button>
-                  </div>
-                  <div data-dropdown-target="menu"
-                       data-transition-enter-active="transition ease-out duration-100"
-                       data-transition-enter-from="transform opacity-0 scale-95"
-                       data-transition-enter-to="transform opacity-100 scale-100"
-                       data-transition-leave-active="transition ease-in duration-75"
-                       data-transition-leave-from="transform opacity-100 scale-100"
-                       data-transition-leave-to="transform opacity-0 scale-95"
-                       class="hidden absolute left-0 mt-2 w-96 bg-white rounded-md ring-1 ring-black ring-opacity-5 shadow-lg origin-top-left md:w-56 focus:outline-none"
-                       role="menu"
-                       aria-orientation="vertical"
-                       aria-labelledby="menu-button"
-                       tabindex="-1">
-                      <form class="p-2" action="" method="get">
-                          <div class="mb-2">
-                              <label class="block text-sm font-medium text-gray-700">
-                                  Is Open Source
-                              </label>
-                              {% render_field filter.form.is_open_source class="block py-2 pr-10 pl-3 mt-1 w-full text-base rounded-md border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %}
-                          </div>
-                          <div class="mb-2">
-                            {% with order_by=request.GET.order_by|default:'updated_date' %}
-                            <label for="order_by" class="block text-sm font-medium text-gray-700">Sort by</label>
-                            <select id="order_by" name="order_by" class="block py-2 pr-10 pl-3 mt-1 w-full text-base rounded-md border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
-                                <option value="updated_date" {% if order_by == 'updated_date' %}selected{% endif %}>Date</option>
-                                <option value="like" {% if order_by == 'like' %}selected{% endif %}>Likes</option>
-                            </select>
-                            {% endwith %}
-                          </div>
-                          <button type="submit"
-                                  data-action="dropdown#toggle"
-                                  class="inline-flex items-center px-2.5 py-1.5 text-xs font-medium text-gray-700 bg-white rounded border border-gray-300 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                              Filter
-                          </button>
-                      </form>
-                  </div>
-              </div>
-
-              <div data-controller="search"
-                  data-search-url-value="/api/v1/search/projects/"
-                  class="relative">
-                <input type="text"
-                        data-search-target="input"
-                        data-action="input->search#onInput"
-                        placeholder="Search projects (Press '/' to focus)"
-                        class="block p-3 w-64 text-gray-900 bg-white rounded-md border border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-                >
-                <div data-search-target="results"
-                      class="hidden overflow-hidden absolute left-0 z-10 mt-2 w-96 bg-white rounded-md shadow-lg">
-                </div>
-            </div>
-
-            </div>
-            <div>
-                <a type="button"
-                   href="{% url 'submit_project' %}"
-                   class="inline-flex items-center px-4 py-2 text-base font-medium text-green-700 bg-green-200 rounded-md border border-transparent border-solid hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-                    Submit a Project
-                </a>
-            </div>
-        </div>
-        <div class="grid grid-cols-1 gap-6 mb-10 lg:grid-cols-3 md:grid-cols-2">
-            {% for site in page_obj %}
-                <div
-                  class="
-                    flex flex-col justify-start bg-white rounded border-solid
-                    {% if site.sponsored %}
-                    border-4 border-yellow-500 shadow-2xl
-                    {% else %}
-                    shadow border-1
-                    {% endif %}
-                  "
-                >
-                    <div class="border-b border-gray-300 border-solid">
-                        <a href="{% url 'project' site.slug %}">
-                            <img
-                              class="
-                                object-cover object-left-top w-full h-auto border-0
-                                {% if not site.sponsored %}
-                                rounded-t
-                                {% endif %}
-                              "
-                              src="{% get_media_prefix %}{{ site.homepage_screenshot }}"
-                              alt="{{ site.title }} | Screenshot"
-                            />
-                        </a>
-                    </div>
-                    <div class="flex-auto p-4 h-full border-b border-gray-300 border-solid">
-                        <h2 class="mb-2 text-lg font-semibold text-gray-900">
-                            <a href="{% url 'project' site.slug %}">{{ site.title }}</a>
-                        </h2>
-                        <p class="text-sm leading-normal text-grey-700">
-                            {{ site.short_description }}
-                        </p>
-                    </div>
-                    <div class="flex justify-between items-center px-4 py-2">
-                        <div>
-                            <a class="inline-block p-2 text-xl bg-gray-200 rounded-lg border border-gray-200 hover:bg-gray-300"
-                               href='{{ site.url }}?ref={{ request.get_host }}&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=list-of-projects-{% now "F-Y" %}-{% if site.sponsored %}sponsored{% else %}unsponsored{% endif %}'
-                               target="_blank">
-                                <i class="las la-link"></i>
-                            </a>
-                            {% if site.github_url %}
-                                <a class="inline-block p-2 text-xl bg-gray-200 rounded-lg border border-gray-200 hover:bg-gray-300"
-                                   href="{{ site.github_url }}?ref={{ request.get_host }}"
-                                   target="_blank">
-                                    <i class="lab la-github"></i>
-                                </a>
-                            {% endif %}
-                            {% if site.twitter_url %}
-                                <a class="inline-block p-2 text-xl bg-gray-200 rounded-lg border border-gray-200 hover:bg-gray-300"
-                                   href="{{ site.twitter_url }}?ref={{ request.get_host }}"
-                                   target="_blank">
-                                    <i class="lab la-twitter"></i>
-                                </a>
-                            {% endif %}
-                        </div>
-
-                        {% include "components/project-likes.html" with site=site %}
-
-                    </div>
-                </div>
-            {% endfor %}
-        </div>
-
-        {% if is_paginated %}
-        <div class="flex justify-center items-center mt-8 space-x-4">
-            {% if page_obj.has_previous %}
-                <a href="?{% if request.GET.order_by %}order_by={{ request.GET.order_by }}&{% endif %}{% if request.GET.is_open_source %}is_open_source={{ request.GET.is_open_source }}&{% endif %}page={{ page_obj.previous_page_number }}"
-                   class="px-4 py-2 text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 hover:bg-gray-50">
-                    Previous
-                </a>
-            {% endif %}
-
-            <span class="text-sm text-gray-700">
-                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
-            </span>
-
-            {% if page_obj.has_next %}
-                <a href="?{% if request.GET.order_by %}order_by={{ request.GET.order_by }}&{% endif %}{% if request.GET.is_open_source %}is_open_source={{ request.GET.is_open_source }}&{% endif %}page={{ page_obj.next_page_number }}"
-                   class="px-4 py-2 text-sm font-medium text-gray-700 bg-white rounded-md border border-gray-300 hover:bg-gray-50">
-                    Next
-                </a>
-            {% endif %}
-        </div>
-        {% endif %}
+      <p class="bw-kicker">Project directory</p>
+      <h1 class="bw-heading-lg mt-3">Django projects worth studying</h1>
+      <p class="bw-lede mt-5">
+        Browse real products, side projects, open source apps, and businesses built with Django. Use them for inspiration, research, and proof that Django can ship.
+      </p>
     </div>
+    <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent">Submit a project</a>
+  </div>
+</section>
+
+<section class="pb-16">
+  <div class="bw-container">
+    <div class="bw-toolbar bw-surface mb-6">
+      <div class="flex flex-col gap-3 md:flex-row md:items-center">
+        <div data-controller="dropdown" class="relative">
+          <button type="button"
+                  data-action="dropdown#toggle click@window->dropdown#hide"
+                  class="bw-button bw-button-secondary w-full md:w-auto"
+                  id="menu-button"
+                  aria-expanded="true"
+                  aria-haspopup="true">
+            <i class="las la-filter" aria-hidden="true"></i>
+            Filter
+          </button>
+          <div data-dropdown-target="menu"
+               data-transition-enter-active="transition ease-out duration-100"
+               data-transition-enter-from="transform opacity-0 scale-95"
+               data-transition-enter-to="transform opacity-100 scale-100"
+               data-transition-leave-active="transition ease-in duration-75"
+               data-transition-leave-from="transform opacity-100 scale-100"
+               data-transition-leave-to="transform opacity-0 scale-95"
+               class="bw-menu-panel hidden absolute left-0 z-20 mt-2 w-[min(22rem,calc(100vw-2rem))] p-4"
+               role="menu"
+               aria-orientation="vertical"
+               aria-labelledby="menu-button">
+            <form class="grid gap-4" action="" method="get">
+              <div>
+                <label class="block text-sm font-black text-[var(--bw-ink)]">Open source</label>
+                {% render_field filter.form.is_open_source class="mt-1 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-sm focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" %}
+              </div>
+              <div>
+                {% with order_by=request.GET.order_by|default:'updated_date' %}
+                  <label for="order_by" class="block text-sm font-black text-[var(--bw-ink)]">Sort by</label>
+                  <select id="order_by" name="order_by" class="mt-1 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-sm focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]">
+                    <option value="updated_date" {% if order_by == 'updated_date' %}selected{% endif %}>Recently updated</option>
+                    <option value="like" {% if order_by == 'like' %}selected{% endif %}>Most liked</option>
+                  </select>
+                {% endwith %}
+              </div>
+              <button type="submit" data-action="dropdown#toggle" class="bw-button bw-button-primary">Apply filters</button>
+            </form>
+          </div>
+        </div>
+
+        <div data-controller="search"
+             data-search-url-value="/api/v1/search/projects/"
+             class="relative">
+          <label for="project-search" class="sr-only">Search projects</label>
+          <input id="project-search"
+                 type="text"
+                 data-search-target="input"
+                 data-action="input->search#onInput"
+                 placeholder="Search projects. Press / to focus."
+                 class="bw-search-input" />
+          <div data-search-target="results" class="bw-menu-panel hidden absolute left-0 z-20 mt-2 w-[min(28rem,calc(100vw-2rem))] overflow-hidden"></div>
+        </div>
+      </div>
+      <p class="text-sm bw-muted">Featured listings appear first. Search is fast when you already know the project or category.</p>
+    </div>
+
+    {% if page_obj %}
+      <div class="bw-project-grid">
+        {% for site in page_obj %}
+          {% include "components/project-card.html" with site=site %}
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="bw-surface p-8 text-center">
+        <h2 class="text-2xl font-black">No projects match those filters</h2>
+        <p class="mx-auto mt-3 max-w-md bw-muted">Try a broader search or submit a Django project that should be here.</p>
+        <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent mt-6">Submit a project</a>
+      </div>
+    {% endif %}
+
+    {% if is_paginated %}
+      <nav class="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row" aria-label="Project pagination">
+        {% if page_obj.has_previous %}
+          <a href="?{% if request.GET.order_by %}order_by={{ request.GET.order_by }}&{% endif %}{% if request.GET.is_open_source %}is_open_source={{ request.GET.is_open_source }}&{% endif %}page={{ page_obj.previous_page_number }}"
+             class="bw-button bw-button-secondary">
+            Previous
+          </a>
+        {% endif %}
+        <span class="rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)] px-4 py-3 text-sm font-bold bw-muted">
+          Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+        </span>
+        {% if page_obj.has_next %}
+          <a href="?{% if request.GET.order_by %}order_by={{ request.GET.order_by }}&{% endif %}{% if request.GET.is_open_source %}is_open_source={{ request.GET.is_open_source }}&{% endif %}page={{ page_obj.next_page_number }}"
+             class="bw-button bw-button-secondary">
+            Next
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
+  </div>
+</section>
 {% endblock content %}
+
 {% block schema %}
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "Projects Built with Django",
-    "description": "Collection of cool projects people built with Django",
+    "description": "Discover real projects and apps built with Django.",
     "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}",
     "author": {

--- a/templates/projects/project_detail.html
+++ b/templates/projects/project_detail.html
@@ -14,217 +14,232 @@
     <meta property="og:title" content="{{ object.title }}" />
     <meta property="og:url" content="https://{{ request.get_host }}/projects/{{ object.slug }}" />
     <meta property="og:description" content="{{ object.short_description }}" />
-    <meta property="og:image" content="https://osig.app/g?style=base&site=facebook&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ object.homepage_screenshot.url }}" />
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta property="og:image" content="https://osig.app/g?style=base&site=facebook&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
     <meta name="twitter:title" content="{{ object.title }}" />
     <meta name="twitter:description" content="{{ object.description }}" />
-    <meta property="og:image" content="https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ object.homepage_screenshot.url }}" />
+    <meta property="og:image" content="https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}" />
 {% endblock meta %}
 
 {% block content %}
-    <p class="mt-4 text-blue-700">
-        ←
-        <a href="{% url 'projects' %}">back to all projects</a>
-    </p>
-
-    <div class="px-6 py-2 bg-white lg:px-8">
-      <div class="mx-auto max-w-2xl text-center">
-        <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">{{ object.title }}</h1>
-        <p class="mt-6 text-lg leading-8 text-gray-600 prose">{{ object.short_description }}</p>
+<section class="bw-page-hero pb-10">
+  <div class="bw-container">
+    <a href="{% url 'projects' %}" class="inline-flex items-center gap-2 text-sm font-black text-[var(--bw-primary-dark)]">
+      <i class="las la-arrow-left" aria-hidden="true"></i>
+      All projects
+    </a>
+    <div class="mt-8 grid gap-8 lg:grid-cols-[1fr_22rem] lg:items-start">
+      <div>
+        <p class="bw-kicker">Django project</p>
+        <h1 class="bw-heading-lg mt-3">{{ object.title }}</h1>
+        <p class="bw-lede mt-5">{{ object.short_description }}</p>
       </div>
+
+      <aside class="bw-surface p-4">
+        <div class="grid gap-3">
+          <a class="bw-button bw-button-primary w-full"
+             href='{{ object.url }}?ref={{ request.get_host }}&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=project-detail-{% now "F-Y" %}-{% if object.sponsored %}sponsored{% else %}unsponsored{% endif %}'
+             target="_blank"
+             rel="noopener">
+            Visit website
+            <i class="las la-external-link-alt" aria-hidden="true"></i>
+          </a>
+          <div class="grid grid-cols-3 gap-2">
+            {% if object.github_url %}
+              <a class="bw-icon-button w-full"
+                 href="{{ object.github_url }}?ref={{ request.get_host }}"
+                 target="_blank"
+                 rel="noopener"
+                 aria-label="{{ object.title }} on GitHub">
+                <i class="lab la-github" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+            {% if object.twitter_url %}
+              <a class="bw-icon-button w-full"
+                 href="{{ object.twitter_url }}?ref={{ request.get_host }}"
+                 target="_blank"
+                 rel="noopener"
+                 aria-label="{{ object.title }} on X">
+                <i class="lab la-twitter" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+            {% include "components/project-likes.html" with site=object %}
+          </div>
+          {% if object.is_for_sale and object.sale_link %}
+            <a class="bw-button bw-button-accent w-full" href="{{ object.sale_link }}" target="_blank" rel="noopener">View sale listing</a>
+          {% endif %}
+          {% if user == object.maker.user or user == object.logged_in_maker %}
+            <a href="{% url 'project_update' object.slug %}" class="bw-button bw-button-secondary w-full">Edit project</a>
+          {% endif %}
+        </div>
+      </aside>
+    </div>
+  </div>
+</section>
+
+<section class="pb-16">
+  <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
+    <div class="grid gap-6">
+      <div class="bw-card">
+        <div class="aspect-[16/10] overflow-hidden bg-[var(--bw-surface-muted)]">
+          {% if object.homepage_screenshot %}
+            <img class="h-full w-full object-cover object-left-top"
+                 src="{% get_media_prefix %}{{ object.homepage_screenshot }}"
+                 alt="{{ object.title }} screenshot"
+                 loading="eager"
+                 decoding="async" />
+          {% else %}
+            <div class="flex h-full items-center justify-center p-8 text-center font-bold bw-muted">Screenshot coming soon</div>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if object.description %}
+        <article class="bw-surface p-5 sm:p-7">
+          <h2 class="text-2xl font-black text-[var(--bw-ink)]">About {{ object.title }}</h2>
+          <div class="bw-prose prose mt-4 max-w-none md:prose-lg">
+            {{ object.description | markdown | safe }}
+          </div>
+        </article>
+      {% endif %}
+
+      {% if object.content_summary or object.target_audience or object.key_features or object.pain_points or object.usage_instructions or object.additional_info %}
+        <article class="bw-surface p-5 sm:p-7">
+          <h2 class="text-2xl font-black text-[var(--bw-ink)]">What to notice</h2>
+          <div class="mt-5 grid gap-5">
+            {% if object.content_summary %}
+              <section class="border-b border-[var(--bw-border)] pb-5 last:border-0 last:pb-0">
+                <h3 class="text-lg font-black">Summary</h3>
+                <div class="bw-prose prose mt-2 max-w-none">{{ object.content_summary | markdown | safe }}</div>
+              </section>
+            {% endif %}
+            {% if object.target_audience %}
+              <section class="border-b border-[var(--bw-border)] pb-5 last:border-0 last:pb-0">
+                <h3 class="text-lg font-black">Target audience</h3>
+                <p class="mt-2 leading-7 bw-muted">{{ object.target_audience }}</p>
+              </section>
+            {% endif %}
+            {% if object.key_features %}
+              <section class="border-b border-[var(--bw-border)] pb-5 last:border-0 last:pb-0">
+                <h3 class="text-lg font-black">Key features</h3>
+                <div class="bw-prose prose mt-2 max-w-none">{{ object.key_features | markdown | safe }}</div>
+              </section>
+            {% endif %}
+            {% if object.pain_points %}
+              <section class="border-b border-[var(--bw-border)] pb-5 last:border-0 last:pb-0">
+                <h3 class="text-lg font-black">Pain points</h3>
+                <div class="bw-prose prose mt-2 max-w-none">{{ object.pain_points | markdown | safe }}</div>
+              </section>
+            {% endif %}
+            {% if object.usage_instructions %}
+              <section class="border-b border-[var(--bw-border)] pb-5 last:border-0 last:pb-0">
+                <h3 class="text-lg font-black">Usage instructions</h3>
+                <div class="bw-prose prose mt-2 max-w-none">{{ object.usage_instructions | markdown | safe }}</div>
+              </section>
+            {% endif %}
+            {% if object.additional_info %}
+              <section class="border-b border-[var(--bw-border)] pb-5 last:border-0 last:pb-0">
+                <h3 class="text-lg font-black">Additional info</h3>
+                <div class="bw-prose prose mt-2 max-w-none">{{ object.additional_info | markdown | safe }}</div>
+              </section>
+            {% endif %}
+          </div>
+        </article>
+      {% endif %}
+
+      {% if object.podcast_episodes.all %}
+        <article class="bw-surface p-5 sm:p-7">
+          <h2 class="text-2xl font-black text-[var(--bw-ink)]">Podcast episodes</h2>
+          <div class="mt-5 grid gap-4">
+            {% for episode in object.podcast_episodes.all %}
+              <a href="{% url 'episode_details' episode.slug %}" class="bw-card grid gap-4 p-4 md:grid-cols-[9rem_1fr]">
+                <img class="aspect-square w-full rounded-md object-cover"
+                     src="{% get_media_prefix %}{{ episode.thumbnail }}"
+                     alt="{{ episode.title }} thumbnail"
+                     loading="lazy"
+                     decoding="async" />
+                <span>
+                  <span class="block text-lg font-black">{{ episode.title }}</span>
+                  <span class="mt-2 block text-sm leading-6 bw-muted">{{ episode.details }}</span>
+                </span>
+              </a>
+            {% endfor %}
+          </div>
+        </article>
+      {% endif %}
     </div>
 
-    <div class="flex flex-col justify-center mx-auto my-10 space-y-2 max-w-5xl">
-        {% if user == object.maker.user or user == object.logged_in_maker %}
-            <div>
-                <a href="{% url 'project_update' object.slug %}"
-                   class="inline-flex items-center px-6 py-3 text-base font-medium text-white bg-green-600 rounded-md border border-transparent shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-                    Edit Project
-                </a>
-            </div>
-        {% endif %}
-
-        <!-- Projects -->
-        <div class="overflow-hidden p-6 bg-white rounded-lg shadow">
-            <div class="overflow-hidden mb-2 bg-white rounded-lg divide-y divide-gray-200 shadow">
-                <div>
-                    <img class="w-full"
-                         src="{% get_media_prefix %}{{ object.homepage_screenshot }}"
-                         alt="{{ object.title }} | Screenshot" />
-                </div>
-            </div>
-            <div class="flex flex-row mb-4 space-x-2 w-full text-center">
-                <a class="inline-flex justify-center items-center px-4 py-3 w-full text-sm font-bold text-center text-white no-underline uppercase bg-green-500 rounded-lg shadow transition flex-no-shrink hover:bg-green-400 hover:-translateY-sm hover:shadow"
-                   href='{{ object.url }}?ref={{ request.get_host }}&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=project-detail-{% now "F-Y" %}-{% if object.sponsored %}sponsored{% else %}unsponsored{% endif %}'
-                   target="_blank">
-                    Visit Website
-                </a>
-                {% if object.github_url %}
-                    <a class="flex items-center bg-gray-100 rounded-lg hover:bg-gray-300"
-                       href="{{ object.github_url }}?ref={{ request.get_host }}"
-                       target="_blank">
-                        <i class="p-2 text-3xl lab la-github"></i>
-                    </a>
-                {% endif %}
-                {% if object.twitter_url %}
-                    <a class="flex items-center bg-gray-100 rounded-lg hover:bg-gray-300"
-                       href="{{ object.twitter_url }}?ref={{ request.get_host }}"
-                       target="_blank">
-                        <i class="p-2 text-3xl text-blue-400 lab la-twitter"></i>
-                    </a>
-                {% endif %}
-                {% include "components/project-likes.html" with site=object %}
-            </div>
-            {% if object.description %}
-                <div aria-hidden="true">
-                    <h2 class="text-lg font-semibold md:text-2xl">
-                        Full Description
-                    </h2>
-                    <div class="text-base prose-sm prose md:prose-lg md:text-lg">
-                        {{ object.description | markdown | safe }}
-                    </div>
-                </div>
+    <aside class="grid content-start gap-4">
+      {% if object.maker.first_name %}
+        <section class="bw-surface p-5">
+          <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Maker</h2>
+          <a href="{{ object.maker.get_absolute_url }}" class="mt-4 flex items-center gap-3">
+            {% if object.maker.maker_profile_image %}
+              <img class="h-14 w-14 rounded-md object-cover"
+                   src="{% get_media_prefix %}{{ object.maker.maker_profile_image }}"
+                   alt="{{ object.maker.first_name }} {{ object.maker.last_name }}" />
+            {% else %}
+              <img class="h-14 w-14 rounded-md object-cover"
+                   src="https://api.dicebear.com/7.x/pixel-art/svg?seed={{ object.maker.slug }}"
+                   alt="" />
             {% endif %}
+            <span>
+              <span class="block font-black">
+                {% if object.maker.first_name %}{{ object.maker.first_name }}{% endif %}
+                {% if object.maker.last_name %}{{ object.maker.last_name }}{% endif %}
+              </span>
+              <span class="block text-sm bw-muted">View maker profile</span>
+            </span>
+          </a>
+          <div class="mt-4 flex gap-2">
+            {% if object.maker.github_handle %}
+              <a class="bw-icon-button" href="https://github.com/{{ object.maker.github_handle }}?ref={{ request.get_host }}" target="_blank" rel="noopener" aria-label="Maker on GitHub">
+                <i class="lab la-github" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+            {% if object.maker.twitter_handle %}
+              <a class="bw-icon-button" href="https://twitter.com/{{ object.maker.twitter_handle }}?ref={{ request.get_host }}" target="_blank" rel="noopener" aria-label="Maker on X">
+                <i class="lab la-twitter" aria-hidden="true"></i>
+              </a>
+            {% endif %}
+          </div>
+        </section>
+      {% endif %}
+
+      <section class="bw-surface p-5">
+        <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Project signals</h2>
+        <div class="mt-4 grid gap-2 text-sm">
+          {% if object.is_open_source %}
+            <p class="rounded-md bg-[var(--bw-primary-soft)] px-3 py-2 font-bold text-[var(--bw-primary-dark)]">Open source</p>
+          {% endif %}
+          {% if object.is_profitable %}
+            <p class="rounded-md bg-[var(--bw-accent-soft)] px-3 py-2 font-bold text-[var(--bw-ink)]">Profitable</p>
+          {% endif %}
+          {% if object.large_company %}
+            <p class="rounded-md bg-[var(--bw-surface-muted)] px-3 py-2 font-bold text-[var(--bw-ink)]">Company-backed</p>
+          {% endif %}
+          {% if object.sponsored %}
+            <p class="rounded-md bg-[var(--bw-accent)] px-3 py-2 font-bold text-[var(--bw-ink)]">Featured listing</p>
+          {% endif %}
         </div>
+      </section>
 
-        <!-- Author Card -->
-        {% if object.maker.first_name %}
-            <div class="overflow-hidden px-6 py-4 bg-white rounded-lg shadow">
-                <a href="{{ object.maker.get_absolute_url }}" class="flex items-center">
-                    <h2 class="text-2xl font-semibold text-black">
-                        Author(s)
-                    </h2>
-                    <div class="flex items-center py-4">
-                        {% if object.maker.maker_profile_image %}
-                            <img class="w-16 h-16 rounded-full"
-                                 src="{% get_media_prefix %}{{ object.maker.maker_profile_image }}"
-                                 alt="" />
-                        {% else %}
-                            <!-- get image gray sillhoutte -->
-                            <img class="w-10 h-10 rounded-full"
-                                 src="https://avatars.dicebear.com/api/gridy/{{ object.maker.slug }}.svg"
-                                 alt="" />
-                        {% endif %}
-                        {% if object.maker.first_name or object.maker.last_name %}
-                            <div class="ml-3">
-                                <p class="text-lg font-medium text-gray-900">
-                                    {% if object.maker.first_name %}{{ object.maker.first_name }}{% endif %}
-                                    {% if object.maker.last_name %}{{ object.maker.last_name }}{% endif %}
-                                </p>
-                                <div>
-                                    {% if object.maker.github_handle %}
-                                        <a class="inline-block rounded-full"
-                                           href="https://github.com/{{ object.maker.github_handle }}?ref={{ request.get_host }}"
-                                           target="_blank">
-                                            <i class="text-2xl lab la-github"></i>
-                                        </a>
-                                    {% endif %}
-                                    {% if object.maker.twitter_handle %}
-                                        <a class="inline-block rounded-full"
-                                           href="https://twitter.com/{{ object.maker.twitter_handle }}?ref={{ request.get_host }}"
-                                           target="_blank">
-                                            <i class="text-2xl lab la-twitter"></i>
-                                        </a>
-                                    {% endif %}
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                </a>
-            </div>
-        {% endif %}
-
-        <!-- Tech Stack Card-->
-        {% if object.technologies.all %}
-            <div class="overflow-hidden px-6 py-4 bg-white rounded-lg shadow">
-                <h2 class="text-2xl font-semibold text-black">
-                    TechStack
-                </h2>
-                <div class="flex flex-wrap items-center py-4 -m-1">
-                    {% for tech in object.technologies.all %}
-                        <div class="inline-flex items-center px-3 m-1 py-1 rounded-full text-md font-medium bg-{{ tech.color }}-100 text-{{ tech.color }}-800">
-                            {{ tech.name }}
-                        </div>
-                    {% endfor %}
-                </div>
-            </div>
-        {% endif %}
-
-        {% if object.podcast_episodes.all %}
-            <div class="overflow-hidden px-6 py-4 bg-white rounded-lg shadow">
-                <h2 class="text-2xl font-semibold text-black">
-                    Podcast Episodes
-                </h2>
-                {% for episode in object.podcast_episodes.all %}
-                    <article class="flex flex-col justify-start mt-4 space-y-4 bg-white rounded border border-solid md:border-0 md:mt-2 md:flex-row">
-                        <header class="rounded-t-lg border-b border-gray-300 border-solid md:border-0">
-                            <a href="{% url 'episode_details' episode.slug %}">
-                                <img class="object-cover object-left-top w-full h-auto rounded-t border-0"
-                                     src="{% get_media_prefix %}{{ episode.thumbnail }}"
-                                     alt="{{ episode.title }} | Screenshot"/>
-                            </a>
-                        </header>
-                        <div class="flex-auto p-4 h-full">
-                            <h2 class="mb-2 text-lg font-semibold text-gray-900">
-                                <a href="">{{ episode.title }}</a>
-                            </h2>
-                            <p class="text-sm leading-normal text-grey-700">
-                                {{ episode.details }}
-                            </p>
-                        </div>
-                    </article>
-                {% endfor %}
-            </div>
-        {% endif %}
-
-        <!-- Additional Info Card-->
-        <div class="rounded-lg prose-lg">
-            {% if object.additional_info %}
-            <div class="-mt-10">
-                <h2>Additional Info</h2>
-                <p>{{ object.additional_info | markdown | safe }}</p>
-            </div>
-            {% endif %}
-
-            {% if project.content_summary %}
-            <div>
-                <h2>Summary</h2>
-                <p>{{ project.content_summary | markdown | safe }}</p>
-            </div>
-            {% endif %}
-
-            {% if project.target_audience %}
-            <div>
-                <h2>Target Audience</h2>
-                <p>{{ project.target_audience }}</p>
-            </div>
-            {% endif %}
-
-            {% if project.key_features %}
-            <div>
-                <h2>Key Features</h2>
-                <p>{{ project.key_features | markdown | safe }}</p>
-            </div>
-            {% endif %}
-
-            {% if project.pain_points %}
-            <div>
-                <h2>Pain Points</h2>
-                <p>{{ project.pain_points | markdown | safe }}</p>
-            </div>
-            {% endif %}
-
-            {% if project.usage_instructions %}
-            <div>
-                <h2>Usage Instructions</h2>
-                <p>{{ project.usage_instructions | markdown | safe }}</p>
-            </div>
-            {% endif %}
-        </div>
-
-      </div>
+      {% if object.technologies.all %}
+        <section class="bw-surface p-5">
+          <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Tech stack</h2>
+          <div class="mt-4 flex flex-wrap gap-2">
+            {% for tech in object.technologies.all %}
+              <span class="inline-flex items-center rounded-md bg-{{ tech.color }}-100 px-3 py-1 text-sm font-black text-{{ tech.color }}-800">
+                {{ tech.name }}
+              </span>
+            {% endfor %}
+          </div>
+        </section>
+      {% endif %}
+    </aside>
+  </div>
+</section>
 {% endblock content %}
 
 {% block schema %}
@@ -240,8 +255,8 @@
     "image": "https://{{ request.get_host }}{% get_media_prefix %}{{ object.maker.maker_profile_image }}"
   },
   "name":"{{ object.title }}",
-  "thumbnailUrl": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ object.homepage_screenshot.url }}",
-  "image": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ object.homepage_screenshot.url }}",
+  "thumbnailUrl": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}",
+  "image": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}",
   "abstract": "{{ object.short_description }}"
 }
     </script>

--- a/templates/projects/submit-project.html
+++ b/templates/projects/submit-project.html
@@ -4,135 +4,108 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Built with Django</title>
-    <meta name="description" content="Collection of cool projects people built with Django" />
+    <title>Submit a Django Project | Built with Django</title>
+    <meta name="description" content="Submit a project to the Built with Django directory." />
     <link rel="canonical" href="https://{{ request.get_host }}/projects/new/" />
-    <meta property="og:title" content="Built with Django" />
+    <meta property="og:title" content="Submit a Django Project | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/projects/new/" />
-    <meta property="og:description" content="Collection of cool projects people built with Django" />
+    <meta property="og:description" content="Submit a project to the Built with Django directory." />
     <meta property="og:image" content="{% static 'vendors/images/logo.png' %}" />
     <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Built with Django" />
-    <meta name="twitter:description" content="Collection of cool projects people built with Django" />
+    <meta name="twitter:site" content="@builtwithdjango" />
+    <meta name="twitter:title" content="Submit a Django Project | Built with Django" />
+    <meta name="twitter:description" content="Submit a project to the Built with Django directory." />
     <meta name="twitter:image" content="{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
 {% block content %}
+<section class="bw-page-hero pb-10">
+  <div class="bw-container">
+    <p class="bw-kicker">Add to the showcase</p>
+    <h1 class="bw-heading-lg mt-3">Submit a Django project</h1>
+    <p class="bw-lede mt-5">Share what you built so other Django developers can learn from it, use it, and send useful attention back to the maker.</p>
+  </div>
+</section>
+
+<section class="pb-16">
+  <div class="bw-container">
     {% if user.is_authenticated %}
-    <div class="mx-auto my-10 max-w-5xl">
-      <div class="overflow-hidden px-6 pt-6 bg-white rounded-lg shadow">
-          <form method="post" enctype="multipart/form-data">
-              {% csrf_token %}
-              {{ form.non_field_errors }}
-              <div class="space-y-8 divide-y divide-gray-200 sm:space-y-5">
-                  <div class="mt-6 space-y-6 sm:mt-5 sm:space-y-5">
-                    <div>
-                      <h3 class="text-lg font-medium leading-6 text-gray-900">Required Information</h3>
-                    </div>
-                    <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                      {{ form.title.errors | safe }}
-                      <label for="title"
-                             class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                          Title
-                      </label>
-                      <div class="mt-1 sm:mt-0 sm:col-span-2">
-                        {% render_field form.title class="block w-full max-w-lg rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm" %}
-                      </div>
-                    </div>
-                    <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                      {{ form.url.errors | safe }}
-                      <label for="url"
-                            class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                          URL
-                      </label>
-                      <div class="mt-1 sm:mt-0 sm:col-span-2">
-                        {% render_field form.url class="block w-full max-w-lg rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm" placeholder="https://example.com" %}
-                      </div>
-                    </div>
-                    <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                        {{ form.short_description.errors | safe }}
-                        <label for="short_description"
-                                class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                            Short Description
-                        </label>
-                        <div class="mt-1 sm:mt-0 sm:col-span-2">
-                          {% render_field form.short_description class="block w-full max-w-lg rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm" %}
-                            <p class="mt-2 text-sm text-gray-500">
-                                Write a few sentences about project (Up to 200 characters).
-                            </p>
-                        </div>
-                    </div>
-                    <div class="pt-8 space-y-6 sm:pt-10 sm:space-y-5">
-                      <div>
-                        <h3 class="text-lg font-medium leading-6 text-gray-900">Optional Information</h3>
-                      </div>
-                      <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                          {{ form.twitter_url.errors | safe }}
-                          <label for="twitter_url"
-                                class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                              Twitter URL
-                          </label>
-                          <div class="mt-1 sm:mt-0 sm:col-span-2">
-                            {% render_field form.twitter_url class="block w-full max-w-lg rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm" placeholder="https://twitter.com/rasulkireev" %}
-                          </div>
-                      </div>
-                      <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                          {{ form.github_url.errors | safe }}
-                          <label for="github_url"
-                                class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                              Github URL
-                          </label>
-                          <div class="mt-1 sm:mt-0 sm:col-span-2">
-                            {% render_field form.github_url class="block w-full max-w-lg rounded-md border-gray-300 shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm" placeholder="https://github.com/rasulkireev" %}
-                          </div>
-                      </div>
-                      <div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5">
-                          {{ form.technology_suggestions_by_user.errors | safe }}
-                          <label for="technology_suggestions_by_user"
-                                class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-2">
-                              Technologies Used
-                          </label>
-                          <div class="mt-1 sm:mt-0 sm:col-span-2">
-                              {% render_field form.technology_suggestions_by_user class="block w-full max-w-lg rounded-md border border-gray-300 shadow-sm focus:ring-green-500 focus:border-green-500 sm:text-sm" rows=6 %}
-                              <p class="mt-2 text-sm text-gray-500">
-                                  Please enter any technologies your site uses (e.g. TailwindCSS, Vuejs, React, or
-                                  <b>
-                                  anything
-                                  </b>
-                                  else that comes to mind.
-                              </p>
-                          </div>
-                      </div>
-                    </div>
-                  </div>
-              </div>
-              <div class="pt-5">
-                  <div class="flex justify-end">
-                      <button type="submit"
-                              class="inline-flex justify-center px-4 py-2 ml-3 text-sm font-medium text-white bg-green-600 rounded-md border border-transparent shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-                          Submit
-                      </button>
-                  </div>
-              </div>
-          </form>
-      </div>
-  </div>
-    {% else %}
+      <div class="grid gap-8 lg:grid-cols-[minmax(0,44rem)_1fr]">
+        <form method="post" enctype="multipart/form-data" class="bw-surface grid gap-8 p-5 sm:p-8">
+          {% csrf_token %}
+          {{ form.non_field_errors }}
 
-    <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
-      <div class="space-y-8 w-full max-w-md">
           <div>
-              <p class="mt-6 text-3xl font-extrabold text-center text-gray-900">
-                  Before you can submit the project please
-                  <a class="font-semibold text-gray-800 underline" href="{% url 'account_signup' %}">create your account</a>
-                  <span class="mt-6 text-xl font-normal text-center text-gray-900">
-                    This helps to prevent spam
-                </span>
-              </p>
+            <h2 class="text-2xl font-black text-[var(--bw-ink)]">Required info</h2>
+            <p class="mt-2 text-sm leading-6 bw-muted">Keep it clear. A real screenshot will be generated after submission.</p>
           </div>
-      </div>
-  </div>
-  {% endif %}
 
+          <div class="grid gap-5">
+            <div>
+              {{ form.title.errors | safe }}
+              <label for="title" class="block text-sm font-black text-[var(--bw-ink)]">Project title</label>
+              {% render_field form.title class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="My Django App" %}
+            </div>
+            <div>
+              {{ form.url.errors | safe }}
+              <label for="url" class="block text-sm font-black text-[var(--bw-ink)]">Project URL</label>
+              {% render_field form.url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://example.com" %}
+            </div>
+            <div>
+              {{ form.short_description.errors | safe }}
+              <label for="short_description" class="block text-sm font-black text-[var(--bw-ink)]">Short description</label>
+              {% render_field form.short_description class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="What does it do, and who is it for?" %}
+              <p class="mt-2 text-sm bw-muted">A few useful sentences, up to 200 characters.</p>
+            </div>
+          </div>
+
+          <div class="border-t border-[var(--bw-border)] pt-8">
+            <h2 class="text-2xl font-black text-[var(--bw-ink)]">Optional signals</h2>
+            <p class="mt-2 text-sm leading-6 bw-muted">These help visitors understand the project faster.</p>
+          </div>
+
+          <div class="grid gap-5">
+            <div class="grid gap-5 sm:grid-cols-2">
+              <div>
+                {{ form.twitter_url.errors | safe }}
+                <label for="twitter_url" class="block text-sm font-black text-[var(--bw-ink)]">X/Twitter URL</label>
+                {% render_field form.twitter_url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://twitter.com/builtwithdjango" %}
+              </div>
+              <div>
+                {{ form.github_url.errors | safe }}
+                <label for="github_url" class="block text-sm font-black text-[var(--bw-ink)]">GitHub URL</label>
+                {% render_field form.github_url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://github.com/example/repo" %}
+              </div>
+            </div>
+            <div>
+              {{ form.technology_suggestions_by_user.errors | safe }}
+              <label for="technology_suggestions_by_user" class="block text-sm font-black text-[var(--bw-ink)]">Technologies used</label>
+              {% render_field form.technology_suggestions_by_user class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" rows=5 placeholder="Django, HTMX, Tailwind, Postgres..." %}
+            </div>
+          </div>
+
+          <button type="submit" class="bw-button bw-button-primary justify-self-start">Submit project</button>
+        </form>
+
+        <aside class="bw-surface self-start p-5">
+          <h2 class="text-xl font-black">What makes a strong listing?</h2>
+          <ul class="mt-4 grid gap-3 text-sm leading-6 bw-muted">
+            <li><strong class="text-[var(--bw-ink)]">A clear use case.</strong> Say who it helps and what problem it solves.</li>
+            <li><strong class="text-[var(--bw-ink)]">A live URL.</strong> Visitors need somewhere to go after the screenshot catches interest.</li>
+            <li><strong class="text-[var(--bw-ink)]">Useful context.</strong> Tech stack links make the project more educational.</li>
+          </ul>
+        </aside>
+      </div>
+    {% else %}
+      <div class="bw-surface mx-auto max-w-xl p-8 text-center">
+        <h2 class="text-3xl font-black text-[var(--bw-ink)]">Create an account first</h2>
+        <p class="mt-4 leading-7 bw-muted">Accounts help prevent spam and let you update your listing later.</p>
+        <div class="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
+          <a class="bw-button bw-button-primary" href="{% url 'account_signup' %}">Create account</a>
+          <a class="bw-button bw-button-secondary" href="{% url 'account_login' %}">Sign in</a>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</section>
 {% endblock content %}


### PR DESCRIPTION
## Summary

Redesigns the Built with Django experience around a friendlier, community-led visual direction while keeping the site practical for people learning and building with Django.

## What changed

- Reworked the global visual system with updated typography, spacing, surfaces, navigation, buttons, cards, and responsive behavior.
- Redesigned the homepage around clearer paths into projects, guides, builders, jobs, and community resources.
- Made the hero showcase tiles navigable so the section has an obvious UX purpose.
- Polished the Django webring footer so it feels integrated rather than pasted on.
- Replaced the graph-paper/checkered background with a greener matte aesthetic and aligned the homepage feature board.
- Added reusable card partials and a short product/design register for future UI work.
- Addressed Greptile feedback by guarding nullable job timestamps and capping homepage jobs to recent approved listings.

## Validation

- Greptile: 5/5 confidence, zero unresolved review threads
- `docker compose exec -T backend python manage.py test pages jobs --keepdb`
- `docker compose exec -T backend python manage.py test pages projects blog jobs users --keepdb`
- `mise exec uv@0.11.16 -- uvx black --check pages/views.py pages/tests.py jobs/tests.py`
- `mise exec uv@0.11.16 -- uvx djlint --profile=django --lint templates/components/job-item.html templates/pages/home.html`
- `npm run build`
- Browser QA on `http://localhost:8000/` across desktop and mobile viewports

Note: GitHub currently reports no branch status checks for this PR. The frontend build still reports existing webpack asset-size/Browserslist warnings.