### PR TITLE
[UI] Polish Production UI Regressions

### DIFF
--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -498,8 +498,9 @@
   .bw-project-card__media img {
     width: 100%;
     height: 100%;
-    object-fit: cover;
-    object-position: left top;
+    background: var(--bw-surface-muted);
+    object-fit: contain;
+    object-position: center top;
     transition: transform 240ms var(--bw-ease);
   }
 
@@ -563,6 +564,15 @@
     background: var(--bw-primary-soft);
     color: var(--bw-primary-dark);
     transform: translateY(-1px);
+  }
+
+  .bw-project-screenshot {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: var(--bw-surface-muted);
+    object-fit: contain;
+    object-position: center top;
   }
 
   .bw-page-hero {

--- a/templates/account/profile-update.html
+++ b/templates/account/profile-update.html
@@ -63,40 +63,6 @@
                   </div>
                 </div>
               </div>
-              <div class="col-span-4 md:col-span-2">
-                <div class="w-full max-w-md mx-auto overflow-hidden bg-white rounded shadow">
-                    <div class="max-w-md mx-auto">
-                      <div class="p-4 sm:p-6">
-                        <p class="mb-1 text-lg font-semibold leading-7 text-gray-700">Django Developers Access</p>
-                        {% if object.has_active_django_devs_subscription %}
-                          <p class="mt-6 prose text-gray-500">
-                            Thanks for subscribing! You should be able to see all <a href="{% url 'developers' %}">Django Developers</a> now.
-                          </p>
-                          <form method="post" class="mt-4 mb-0" action="{% url 'create-customer-portal-session' %}">
-                            {% csrf_token %}
-                            <button
-                              class="inline-flex items-center px-3 py-2 text-white bg-green-600 border-2 border-transparent rounded-md hover:bg-green-700"
-                              type="submit"
-                            >
-                              Manage Subscription
-                            </button>
-                          </form>
-                        {% else %}
-                        <div class="flex flex-row">
-                          <p class="font-semibold">$299 / month</p>
-                        </div>
-                        <p class="mt-6 prose text-gray-500">If you are a business looking for good quality <a href="{% url 'developers' %}">Django Developers</a>, this is for you.</p>
-                          <a href="{% url 'checkout-django-devs' %}" class="block mt-10 w-full px-4 py-3 font-medium tracking-wide text-center capitalize transition-colors duration-300 transform bg-yellow-400 rounded hover:bg-yellow-500">
-                              Subscribe
-                          </a>
-                        <a href="{% url 'developers-pricing' %}" class="block mt-1.5 w-full px-4 py-3 font-medium tracking-wide text-center capitalize transition-colors duration-300 transform rounded hover:bg-gray-200">
-                              Detailed Pricing
-                        </a>
-                        {% endif %}
-                      </div>
-                    </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -113,7 +79,7 @@
           <div class="md:grid md:grid-cols-3 md:gap-6">
             <div class="md:col-span-1">
               <h3 class="text-base font-semibold leading-6 text-gray-900">Personal Information</h3>
-              <p class="mt-1 text-sm text-gray-500">This info can be useful to share if you want to be discovered by other makers</p>
+              <p class="mt-1 text-sm text-gray-500">This info helps personalize your account.</p>
             </div>
             <div class="mt-5 space-y-6 md:col-span-2 md:mt-0">
               <div class="grid grid-cols-4 gap-6">
@@ -167,93 +133,6 @@
                     {% render_field form.profile_image class="hidden" %}
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-
-        </div>
-        <div class="px-4 py-3 text-right bg-gray-50 sm:px-6">
-          <button type="submit" class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-gray-800 border border-transparent rounded-md shadow-sm hover:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2">Save</button>
-        </div>
-      </div>
-    </form>
-  </section>
-
-  <section aria-labelledby="developer-profile">
-    <form method="post" action="{% url 'update_developer' current_developer.id %}">
-      {% csrf_token %}
-      {{ developer_form.non_field_errors }}
-      <div class="shadow sm:overflow-hidden sm:rounded-md">
-        <div class="px-4 py-6 bg-white sm:p-6">
-          <div class="md:grid md:grid-cols-3 md:gap-6">
-            <div class="md:col-span-1">
-              <h3 class="text-base font-semibold leading-6 text-gray-900">Developer Profile</h3>
-              <p class="mt-1 text-sm text-gray-500">
-                This info will be displayed on your Django Developer Profile. Please make sure
-                to fill out the "Personal Information" block above if you doing a Django Developer profile.
-              </p>
-            </div>
-            <div class="mt-5 space-y-6 md:col-span-2 md:mt-0">
-              <div class="grid grid-cols-4 gap-6 mt-6">
-                <div class="col-span-4">
-                  <div class="relative flex items-start">
-                    {{ developer_form.looking_for_a_job.errors }}
-                    <div class="flex items-center h-6">
-                      {% render_field developer_form.looking_for_a_job name="looking-for-a-job" id="looking-for-a-job" class="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-600" %}
-                    </div>
-                    <div class="ml-3">
-                      <label for="looking-for-a-job" class="text-sm font-medium leading-6 prose text-gray-900">Display Profile on <a href="{% url 'developers' %}">Django Developers</a></label>
-                      {% comment %} <p class="text-sm text-gray-500">This setting will display your profile in Django Devs section.</p> {% endcomment %}
-                    </div>
-                  </div>
-                </div>
-
-                <div class="col-span-4">
-                  <label for="title" class="block text-sm font-medium text-gray-700">Title</label>
-                  {{ developer_form.title.errors }}
-                  {% render_field developer_form.title name="title" id="title" placeholder="Passionate Senior Django Developer with over 6 years of experience | React, DRF" class="block w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                </div>
-                <div class="col-span-4">
-                  {{ developer_form.description.errors }}
-                  <label for="description" class="block text-sm font-medium text-gray-700">Description</label>
-                  {% render_field developer_form.description name="description" rows=10 id="description" rows="4" class="block w-full px-3 py-2 mt-1 rounded-md border-0 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:py-1.5 sm:text-sm sm:leading-6" %}
-                  <p class="mt-2 text-sm text-gray-500">This will show up as you main description. Write whatever you want here, except for any personal identifieable information. Also, all links and images will be removed.</p>
-                  <p class="mt-2 text-sm italic text-gray-400">Hint: Use Markdown</p>
-                </div>
-                <div class="col-span-4 sm:col-span-2">
-                  {{ developer_form.status.errors }}
-                  <label for="status" class="block text-sm font-medium text-gray-700"> Status </label>
-                  {% render_field developer_form.status id="status" class="block w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                </div>
-                <div class="col-span-4 sm:col-span-2">
-                  {{ developer_form.role.errors }}
-                  <label for="role" class="block text-sm font-medium text-gray-700"> Experience </label>
-                  {% render_field developer_form.role id="role" class="block w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                </div>
-                <div class="col-span-4 sm:col-span-2">
-                  {{ developer_form.location.errors }}
-                  <label for="{{ developer_form.location.id_for_label }}" class="block text-sm font-medium text-gray-700"> Location </label>
-                  {% render_field developer_form.location type="text" placeholder="New York, USA" class="block w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                </div>
-                <div class="col-span-4 sm:col-span-2">
-                  {{ developer_form.timezone.errors }}
-                  <label for="{{ developer_form.timezone.id_for_label }}" class="block text-sm font-medium text-gray-700"> Timezone </label>
-                  {% render_field developer_form.timezone type="text" placeholder="New York, USA" class="block w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                </div>
-                <div class="col-span-4 sm:col-span-2">
-                  {{ developer_form.salary_expectation.errors }}
-                  <label for="{{ developer_form.salary_expectation.id_for_label }}" class="block text-sm font-medium text-gray-700"> Salary Expectation </label>
-                  <div class="grid grid-cols-4 gap-1">
-                    {% render_field developer_form.salary_expectation class="col-span-2 px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                    {% render_field developer_form.salary_cadence class="col-span-1 px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:border-gray-900 focus:outline-none focus:ring-gray-900 sm:text-sm" %}
-                  </div>
-                </div>
-                <div class="col-span-4">
-                  {{ developer_form.custom_capacity_field.errors }}
-                  <label for="{{ developer_form.custom_capacity_field.id_for_label }}" class="block text-sm font-medium text-gray-700"> Capacity </label>
-                  {% render_field developer_form.custom_capacity_field class="rounded" %}
-                </div>
-
               </div>
             </div>
           </div>

--- a/templates/account/profile-update.html
+++ b/templates/account/profile-update.html
@@ -38,7 +38,7 @@
           </div>
           <div class="mt-5 space-y-6 md:col-span-2 md:mt-0">
             <div class="grid grid-cols-4 gap-6 mt-6">
-              <div class="col-span-4 md:col-span-2">
+              <div class="col-span-4">
                 <div class="w-full max-w-md mx-auto overflow-hidden bg-white rounded shadow">
                   <div class="max-w-md mx-auto">
                     <div class="p-4 sm:p-6">

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,6 @@
           <a href="{% url 'projects' %}" class="bw-nav-link">Projects</a>
           <a href="{% url 'blog' %}" class="bw-nav-link">Guides</a>
           <a href="{% url 'jobs' %}" class="bw-nav-link">Jobs</a>
-          <a href="{% url 'developers' %}" class="bw-nav-link">Developers</a>
           <div data-controller="dropdown" class="relative">
             <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" class="bw-nav-link" aria-expanded="false">
               Resources
@@ -87,13 +86,6 @@
                   <span>
                     <span class="block font-bold">Podcast</span>
                     <span class="block text-sm bw-muted">Conversations with Django builders.</span>
-                  </span>
-                </a>
-                <a href="{% url 'makers' %}" class="bw-menu-item">
-                  <span class="bw-menu-icon"><i class="las la-users" aria-hidden="true"></i></span>
-                  <span>
-                    <span class="block font-bold">Makers</span>
-                    <span class="block text-sm bw-muted">People shipping with Django.</span>
                   </span>
                 </a>
                 <a href="{% url 'advertize' %}" class="bw-menu-item">
@@ -192,7 +184,6 @@
               <a href="{% url 'projects' %}" class="bw-mobile-link">Projects <i class="las la-arrow-right" aria-hidden="true"></i></a>
               <a href="{% url 'blog' %}" class="bw-mobile-link">Guides <i class="las la-arrow-right" aria-hidden="true"></i></a>
               <a href="{% url 'jobs' %}" class="bw-mobile-link">Jobs <i class="las la-arrow-right" aria-hidden="true"></i></a>
-              <a href="{% url 'developers' %}" class="bw-mobile-link">Developers <i class="las la-arrow-right" aria-hidden="true"></i></a>
             </div>
             <div>
               <p class="mb-2 text-xs font-black uppercase tracking-wider bw-muted">Tools and community</p>
@@ -229,7 +220,7 @@
             <span>Built with Django</span>
           </a>
           <p class="mt-4 max-w-md text-sm leading-6 text-[oklch(82%_0.03_126)]">
-            A community showcase for Django projects, guides, jobs, and the builders behind them.
+            A community showcase for Django projects, guides, jobs, and the ecosystem around them.
           </p>
           <p class="mt-6 text-xs text-[oklch(70%_0.025_126)]">
             &copy; 2026 <a href="https://lvtd.dev">LVTD, LLC</a>. Curated by <a href="https://rasulkireev.com">Rasul Kireev</a>.
@@ -241,7 +232,6 @@
             <a href="{% url 'projects' %}">Projects</a>
             <a href="{% url 'blog' %}">Guides</a>
             <a href="{% url 'jobs' %}">Jobs</a>
-            <a href="{% url 'developers' %}">Developers</a>
             <a href="{% url 'podcast_episodes' %}">Podcast</a>
           </div>
         </div>

--- a/templates/blog/post_detail.html
+++ b/templates/blog/post_detail.html
@@ -40,7 +40,7 @@
 <div data-controller="exit-intent" data-action="mouseout@document->exit-intent#openModal">
 {# djlint:on #}
   <section class="pb-16">
-    <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,48rem)_18rem] lg:items-start">
+    <div class="bw-container max-w-4xl">
       <article class="bw-surface p-5 sm:p-8">
         <div class="bw-prose prose max-w-none md:prose-lg">
           <div class="blog-post">
@@ -48,16 +48,6 @@
           </div>
         </div>
       </article>
-      <aside class="hidden lg:block lg:sticky lg:top-24">
-        <div class="bw-surface p-5">
-          <h2 class="text-xl font-black">Keep learning Django</h2>
-          <p class="mt-2 text-sm leading-6 bw-muted">Browse more guides or study real projects from the community.</p>
-          <div class="mt-5 grid gap-2">
-            <a href="{% url 'blog' %}" class="bw-button bw-button-secondary">More guides</a>
-            <a href="{% url 'projects' %}" class="bw-button bw-button-primary">Project directory</a>
-          </div>
-        </div>
-      </aside>
     </div>
   </section>
 </div>

--- a/templates/components/bottom-right-corner-ad.html
+++ b/templates/components/bottom-right-corner-ad.html
@@ -1,13 +1,15 @@
-<aside id="ad-container-mobile" class="fixed inset-x-0 bottom-0 z-50 hidden border-t border-[var(--bw-border)] bg-[var(--bw-surface)] shadow-lg lg:hidden">
+<aside id="ad-container-mobile" class="fixed inset-x-0 bottom-0 z-50 hidden border-t border-[var(--bw-border-strong)] bg-[oklch(96.5%_0.025_128)] shadow-lg lg:hidden">
   <div class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3">
     <a target="_blank"
        rel="noopener"
-       href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'
+       href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'
        class="flex min-w-0 items-center gap-3">
-      <img src="https://tuxseo.com/static/vendors/images/logo.png" alt="TuxSEO" class="h-10 w-10 rounded-md object-contain" />
+      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--bw-border)] bg-[oklch(99%_0.01_118)]">
+        <img src="https://djass.dev/static/vendors/images/logo.6e2255bebd12.svg" alt="Djass" class="h-7 w-7 object-contain" />
+      </span>
       <span class="min-w-0">
-        <span class="block text-sm font-black text-[var(--bw-ink)]">TuxSEO <span class="font-bold bw-muted">Ad</span></span>
-        <span class="block truncate text-xs bw-muted">AI-powered blog content generation.</span>
+        <span class="block text-sm font-black text-[var(--bw-ink)]">Djass <span class="font-bold bw-muted">Ad</span></span>
+        <span class="block truncate text-xs bw-muted">Generate production-ready Django SaaS repos.</span>
       </span>
     </a>
     <button class="bw-icon-button close-ad shrink-0" type="button" aria-label="Close ad">
@@ -16,21 +18,21 @@
   </div>
 </aside>
 
-<aside id="ad-container-desktop" class="fixed bottom-4 right-4 z-50 hidden w-72 rounded-lg border border-[var(--bw-border)] bg-[var(--bw-surface)] p-4 shadow-lg lg:block">
+<aside id="ad-container-desktop" class="fixed bottom-4 right-4 z-50 hidden w-80 rounded-lg border border-[var(--bw-border-strong)] bg-[oklch(96.5%_0.025_128)] p-4 shadow-lg lg:block">
   <p class="text-xs font-black uppercase tracking-wider bw-muted">Ad</p>
   <div class="mt-2 flex gap-3">
     <a target="_blank"
        rel="noopener"
-       href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
-       class="shrink-0">
-      <img src="https://tuxseo.com/static/vendors/images/logo.png" alt="TuxSEO" class="h-14 w-14 rounded-md object-contain" />
+       href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
+       class="flex h-14 w-14 shrink-0 items-center justify-center rounded-md border border-[var(--bw-border)] bg-[oklch(99%_0.01_118)]">
+      <img src="https://djass.dev/static/vendors/images/logo.6e2255bebd12.svg" alt="Djass" class="h-10 w-10 object-contain" />
     </a>
     <div class="min-w-0">
       <a target="_blank"
          rel="noopener"
-         href='https://tuxseo.com/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
-         class="font-black text-[var(--bw-primary-dark)]">TuxSEO</a>
-      <p class="mt-1 text-sm leading-5 bw-muted">AI-powered blog content generation.</p>
+         href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
+         class="font-black text-[var(--bw-primary-dark)]">Djass</a>
+      <p class="mt-1 text-sm leading-5 bw-muted">Generate a production-ready Django SaaS starter repo.</p>
     </div>
   </div>
   <button class="bw-icon-button close-ad absolute right-2 top-2 h-8 min-h-0 w-8 min-w-0" type="button" aria-label="Close ad">

--- a/templates/components/bottom-right-corner-ad.html
+++ b/templates/components/bottom-right-corner-ad.html
@@ -5,7 +5,7 @@
        href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'
        class="flex min-w-0 items-center gap-3">
       <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--bw-border)] bg-[oklch(99%_0.01_118)]">
-        <img src="https://djass.dev/static/vendors/images/logo.6e2255bebd12.svg" alt="Djass" class="h-7 w-7 object-contain" />
+        <img src="https://djass.dev/static/vendors/images/logo.svg" alt="Djass" class="h-7 w-7 object-contain" />
       </span>
       <span class="min-w-0">
         <span class="block text-sm font-black text-[var(--bw-ink)]">Djass <span class="font-bold bw-muted">Ad</span></span>
@@ -25,7 +25,7 @@
        rel="noopener"
        href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
        class="flex h-14 w-14 shrink-0 items-center justify-center rounded-md border border-[var(--bw-border)] bg-[oklch(99%_0.01_118)]">
-      <img src="https://djass.dev/static/vendors/images/logo.6e2255bebd12.svg" alt="Djass" class="h-10 w-10 object-contain" />
+      <img src="https://djass.dev/static/vendors/images/logo.svg" alt="Djass" class="h-10 w-10 object-contain" />
     </a>
     <div class="min-w-0">
       <a target="_blank"

--- a/templates/components/project-likes.html
+++ b/templates/components/project-likes.html
@@ -29,7 +29,7 @@
               <div>
                 <h3 class="text-xl font-black text-[var(--bw-ink)]" id="modal-title">Sign in to save projects</h3>
                 <p class="mt-2 text-sm leading-6 bw-muted">
-                  Liking projects helps you build a personal shortlist and gives makers a signal that their work is useful.
+                  Liking projects helps you build a personal shortlist and gives project owners a signal that their work is useful.
                 </p>
               </div>
               <button data-action="click->like#toggleModal"

--- a/templates/jobs/all_all_jobs.html
+++ b/templates/jobs/all_all_jobs.html
@@ -4,17 +4,17 @@
 
 {% block meta %}
     <title>Django Jobs</title>
-    <meta name="description" content="Best jobs for best Django Developers!"/>
+    <meta name="description" content="Django jobs for people who want to work with Django."/>
     <link rel="canonical" href="https://{{ request.get_host }}/jobs/" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
     <meta name="twitter:title" content="Django Jobs" />
-    <meta name="twitter:description" content="Best jobs for best Django Developers!"/>
+    <meta name="twitter:description" content="Django jobs for people who want to work with Django."/>
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
     <meta property="og:title" content="Django Jobs" />
     <meta property="og:url" content="https://{{ request.get_host }}/jobs/" />
-    <meta property="og:description" content="Best jobs for best Django Developers!"/>
+    <meta property="og:description" content="Django jobs for people who want to work with Django."/>
     <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
@@ -23,7 +23,7 @@
     <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
       <div class="max-w-2xl mx-auto text-center">
         <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Jobs</h1>
-        <p class="mt-6 text-lg leading-8 prose text-gray-600">Advertize your jobs to the best Django Developers out there.</p>
+        <p class="mt-6 text-lg leading-8 prose text-gray-600">Advertize your jobs to people who want to work with Django.</p>
       </div>
       <div class="flex flex-wrap items-center justify-between mt-8 sm:flex-nowrap">
           <div class="mx-auto">
@@ -70,8 +70,8 @@
     "@type": "WebSite",
     "name": "Django Jobs",
     "about": "Job Board",
-    "description": "Best jobs for best Django Developers!",
-    "abstract": "Best jobs for best Django Developers!",
+    "description": "Django jobs for people who want to work with Django.",
+    "abstract": "Django jobs for people who want to work with Django.",
     "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}/jobs/",
     "author": {

--- a/templates/jobs/post-job.html
+++ b/templates/jobs/post-job.html
@@ -20,7 +20,7 @@
 {% block content %}
 <section class="bw-page-hero pb-10">
   <div class="bw-container">
-    <p class="bw-kicker">Reach Django developers</p>
+    <p class="bw-kicker">Reach Django builders</p>
     <h1 class="bw-heading-lg mt-3">Post a Django job</h1>
     <p class="bw-lede mt-5">Share the core role details. The listing URL lets us fill in the rest and send people to your canonical job post.</p>
   </div>
@@ -83,7 +83,7 @@
       <ul class="mt-4 grid gap-3 text-sm leading-6 bw-muted">
         <li><strong class="text-[var(--bw-ink)]">Django-specific audience.</strong> Reach people who already care about this stack.</li>
         <li><strong class="text-[var(--bw-ink)]">Simple submission.</strong> The listing URL keeps the source of truth on your site.</li>
-        <li><strong class="text-[var(--bw-ink)]">Community context.</strong> Jobs sit alongside projects, guides, and developer profiles.</li>
+        <li><strong class="text-[var(--bw-ink)]">Community context.</strong> Jobs sit alongside projects, guides, and practical community resources.</li>
       </ul>
     </aside>
   </div>

--- a/templates/newsletter/weekly-newsletter-template.html
+++ b/templates/newsletter/weekly-newsletter-template.html
@@ -38,12 +38,6 @@
                            target="_blank">
                             {{ project.title }}
                         </a>
-                        by
-                        <a href="https://builtwithdjango.com{{ project.maker.get_absolute_url }}"
-                           rel="noopener noreferrer"
-                           target="_blank">
-                            {{ project.maker.first_name }} {{ project.maker.last_name }}
-                        </a>
                     </p>
                     <p style="margin: 0 0 10px 0; padding:0; font-size: 12px; color: rgba(55, 65, 81, 1);">
                         {{ project.short_description }}

--- a/templates/newsletter/weekly-newsletter-template.md
+++ b/templates/newsletter/weekly-newsletter-template.md
@@ -6,7 +6,7 @@
 ## Projects
 
 {% for project in projects %}
-- [{{ project.title }}](https://builtwithdjango.com{{ project.get_absolute_url }}) - {% if project.maker %}by [{{ project.maker.first_name }} {{ project.maker.last_name }}](https://builtwithdjango.com{{ project.maker.get_absolute_url }}):{% endif %} {{ project.short_description }}
+- [{{ project.title }}](https://builtwithdjango.com{{ project.get_absolute_url }}) - {{ project.short_description }}
 {% endfor %}
 
 ---

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -12,7 +12,7 @@
       </p>
       <h1 class="bw-heading-xl mt-5">Built with Django</h1>
       <p class="bw-lede mt-6">
-        See what people are shipping with Django, learn from practical guides, find Django work, and discover builders from the community.
+        See what people are shipping with Django, learn from practical guides, find Django work, and discover useful community resources.
       </p>
       <div class="mt-8 flex flex-col gap-3 sm:flex-row">
         <a href="{% url 'projects' %}" class="bw-button bw-button-primary">
@@ -26,7 +26,7 @@
     <div class="bw-hero-showcase">
       <div class="bw-hero-showcase__header">
         <p class="bw-hero-showcase__label">Start with the community</p>
-        <p class="bw-hero-showcase__note">Pick a path into projects, guides, people, or Django work.</p>
+        <p class="bw-hero-showcase__note">Pick a path into projects, guides, tools, or Django work.</p>
       </div>
       <div class="grid gap-3 sm:grid-cols-2">
         {% if projects %}
@@ -37,7 +37,7 @@
                   <img
                     src="{% get_media_prefix %}{{ project.homepage_screenshot }}"
                     alt="{{ project.title }} screenshot"
-                    class="h-full w-full object-cover object-left-top transition duration-200 group-hover:scale-[1.025]"
+                    class="bw-project-screenshot transition duration-200 group-hover:scale-[1.025]"
                     loading="{% if forloop.counter <= 2 %}eager{% else %}lazy{% endif %}"
                     decoding="async"
                   />
@@ -74,14 +74,14 @@
               <i class="las la-arrow-right" aria-hidden="true"></i>
             </span>
           </a>
-          <a href="{% url 'developers' %}" class="bw-hero-placeholder">
+          <a href="{% url 'podcast_episodes' %}" class="bw-hero-placeholder">
             <span>
-              <span class="bw-menu-icon"><i class="las la-users" aria-hidden="true"></i></span>
-              <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Builder profiles</span>
-              <span class="mt-2 block text-sm leading-6 bw-muted">People, makers, and teams shipping in public.</span>
+              <span class="bw-menu-icon"><i class="las la-microphone-alt" aria-hidden="true"></i></span>
+              <span class="mt-5 block text-xl font-black leading-tight text-[var(--bw-ink)]">Django conversations</span>
+              <span class="mt-2 block text-sm leading-6 bw-muted">Podcast episodes and practical context from the ecosystem.</span>
             </span>
             <span class="bw-hero-placeholder__action">
-              Meet developers
+              Listen in
               <i class="las la-arrow-right" aria-hidden="true"></i>
             </span>
           </a>
@@ -113,7 +113,7 @@
       </div>
       <div>
         <p class="font-black text-[var(--bw-ink)]">Community signals</p>
-        <p class="mt-1 text-sm bw-muted">Jobs, makers, developers, and useful tools.</p>
+        <p class="mt-1 text-sm bw-muted">Jobs, useful tools, launches, and resources.</p>
       </div>
     </div>
   </div>
@@ -121,7 +121,7 @@
 
 <section class="bw-section pt-0">
   <div class="bw-container">
-    <div class="grid gap-4 md:grid-cols-4">
+    <div class="grid gap-4 md:grid-cols-3">
       <a href="{% url 'projects' %}" class="bw-card p-5">
         <span class="bw-menu-icon"><i class="las la-window-restore" aria-hidden="true"></i></span>
         <h2 class="mt-5 text-2xl font-black leading-tight">Browse projects</h2>
@@ -135,12 +135,7 @@
       <a href="{% url 'jobs' %}" class="bw-card p-5">
         <span class="bw-menu-icon"><i class="las la-briefcase" aria-hidden="true"></i></span>
         <h2 class="mt-5 text-2xl font-black leading-tight">Find Django work</h2>
-        <p class="mt-3 text-sm leading-6 bw-muted">A job board for teams and developers who want Django experience.</p>
-      </a>
-      <a href="{% url 'developers' %}" class="bw-card p-5">
-        <span class="bw-menu-icon"><i class="las la-user-astronaut" aria-hidden="true"></i></span>
-        <h2 class="mt-5 text-2xl font-black leading-tight">Meet developers</h2>
-        <p class="mt-3 text-sm leading-6 bw-muted">Find Django people who are available for contracts, roles, and collaborations.</p>
+        <p class="mt-3 text-sm leading-6 bw-muted">A job board for teams hiring for Django experience.</p>
       </a>
     </div>
   </div>

--- a/templates/podcast/all_episodes.html
+++ b/templates/podcast/all_episodes.html
@@ -7,15 +7,15 @@
     <meta name="twitter:site" content="@builtwithdjango" />
     <title>Built with Django | Podcast</title>
     <meta name="description"
-          content="Built with Django Podcast is an awesome way to catch up with best makers and best practices in the Django community."/>
+          content="Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community."/>
     <link rel="canonical" href="https://{{ request.get_host }}/podcast/" />
     <meta property="og:title" content="Built with Django | Podcast" />
     <meta property="og:url" content="https://{{ request.get_host }}/podcast/" />
     <meta property="og:description"
-          content="Built with Django Podcast is an awesome way to catch up with best makers and best practices in the Django community."/>
+          content="Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community."/>
     <meta name="twitter:title" content="Built with Django | Podcast" />
     <meta name="twitter:description"
-          content="Built with Django Podcast is an awesome way to catch up with best makers and best practices in the Django community."/>
+          content="Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community."/>
     <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 
@@ -24,7 +24,7 @@
     <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
       <div class="max-w-2xl mx-auto text-center">
         <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Built with Django Podcast</h1>
-        <p class="mt-6 text-lg leading-8 prose text-gray-600">Insights from the Best Django Developers</p>
+        <p class="mt-6 text-lg leading-8 prose text-gray-600">Practical stories from the Django community</p>
       </div>
     </div>
 
@@ -59,8 +59,8 @@
     "@context": "https://schema.org",
     "@type": "PodcastSeries",
     "name": "Built with Django Podcast",
-    "description": "Built with Django Podcast is an awesome way to catch up with best makers and best practices in the Django community.",
-    "abstract": "Built with Django Podcast is an awesome way to catch up with best makers and best practices in the Django community.",
+    "description": "Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community.",
+    "abstract": "Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community.",
     "image": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
     "url": "https://{{ request.get_host }}/podcast/",
     "author": {

--- a/templates/projects/project_detail.html
+++ b/templates/projects/project_detail.html
@@ -79,12 +79,12 @@
 </section>
 
 <section class="pb-16">
-  <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,1fr)_20rem]">
+  <div class="bw-container-wide grid gap-8">
     <div class="grid gap-6">
       <div class="bw-card">
         <div class="aspect-[16/10] overflow-hidden bg-[var(--bw-surface-muted)]">
           {% if object.homepage_screenshot %}
-            <img class="h-full w-full object-cover object-left-top"
+            <img class="bw-project-screenshot"
                  src="{% get_media_prefix %}{{ object.homepage_screenshot }}"
                  alt="{{ object.title }} screenshot"
                  loading="eager"
@@ -96,7 +96,7 @@
       </div>
 
       {% if object.description %}
-        <article class="bw-surface p-5 sm:p-7">
+        <article class="bw-surface p-5 sm:p-7 lg:mx-auto lg:w-full lg:max-w-4xl">
           <h2 class="text-2xl font-black text-[var(--bw-ink)]">About {{ object.title }}</h2>
           <div class="bw-prose prose mt-4 max-w-none md:prose-lg">
             {{ object.description | markdown | safe }}
@@ -104,8 +104,21 @@
         </article>
       {% endif %}
 
+      {% if object.technologies.all %}
+        <article class="bw-surface p-5 sm:p-7 lg:mx-auto lg:w-full lg:max-w-4xl">
+          <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Tech stack</h2>
+          <div class="mt-4 flex flex-wrap gap-2">
+            {% for tech in object.technologies.all %}
+              <span class="inline-flex items-center rounded-md bg-{{ tech.color }}-100 px-3 py-1 text-sm font-black text-{{ tech.color }}-800">
+                {{ tech.name }}
+              </span>
+            {% endfor %}
+          </div>
+        </article>
+      {% endif %}
+
       {% if object.content_summary or object.target_audience or object.key_features or object.pain_points or object.usage_instructions or object.additional_info %}
-        <article class="bw-surface p-5 sm:p-7">
+        <article class="bw-surface p-5 sm:p-7 lg:mx-auto lg:w-full lg:max-w-4xl">
           <h2 class="text-2xl font-black text-[var(--bw-ink)]">What to notice</h2>
           <div class="mt-5 grid gap-5">
             {% if object.content_summary %}
@@ -149,7 +162,7 @@
       {% endif %}
 
       {% if object.podcast_episodes.all %}
-        <article class="bw-surface p-5 sm:p-7">
+        <article class="bw-surface p-5 sm:p-7 lg:mx-auto lg:w-full lg:max-w-4xl">
           <h2 class="text-2xl font-black text-[var(--bw-ink)]">Podcast episodes</h2>
           <div class="mt-5 grid gap-4">
             {% for episode in object.podcast_episodes.all %}
@@ -169,75 +182,6 @@
         </article>
       {% endif %}
     </div>
-
-    <aside class="grid content-start gap-4">
-      {% if object.maker.first_name %}
-        <section class="bw-surface p-5">
-          <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Maker</h2>
-          <a href="{{ object.maker.get_absolute_url }}" class="mt-4 flex items-center gap-3">
-            {% if object.maker.maker_profile_image %}
-              <img class="h-14 w-14 rounded-md object-cover"
-                   src="{% get_media_prefix %}{{ object.maker.maker_profile_image }}"
-                   alt="{{ object.maker.first_name }} {{ object.maker.last_name }}" />
-            {% else %}
-              <img class="h-14 w-14 rounded-md object-cover"
-                   src="https://api.dicebear.com/7.x/pixel-art/svg?seed={{ object.maker.slug }}"
-                   alt="" />
-            {% endif %}
-            <span>
-              <span class="block font-black">
-                {% if object.maker.first_name %}{{ object.maker.first_name }}{% endif %}
-                {% if object.maker.last_name %}{{ object.maker.last_name }}{% endif %}
-              </span>
-              <span class="block text-sm bw-muted">View maker profile</span>
-            </span>
-          </a>
-          <div class="mt-4 flex gap-2">
-            {% if object.maker.github_handle %}
-              <a class="bw-icon-button" href="https://github.com/{{ object.maker.github_handle }}?ref={{ request.get_host }}" target="_blank" rel="noopener" aria-label="Maker on GitHub">
-                <i class="lab la-github" aria-hidden="true"></i>
-              </a>
-            {% endif %}
-            {% if object.maker.twitter_handle %}
-              <a class="bw-icon-button" href="https://twitter.com/{{ object.maker.twitter_handle }}?ref={{ request.get_host }}" target="_blank" rel="noopener" aria-label="Maker on X">
-                <i class="lab la-twitter" aria-hidden="true"></i>
-              </a>
-            {% endif %}
-          </div>
-        </section>
-      {% endif %}
-
-      <section class="bw-surface p-5">
-        <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Project signals</h2>
-        <div class="mt-4 grid gap-2 text-sm">
-          {% if object.is_open_source %}
-            <p class="rounded-md bg-[var(--bw-primary-soft)] px-3 py-2 font-bold text-[var(--bw-primary-dark)]">Open source</p>
-          {% endif %}
-          {% if object.is_profitable %}
-            <p class="rounded-md bg-[var(--bw-accent-soft)] px-3 py-2 font-bold text-[var(--bw-ink)]">Profitable</p>
-          {% endif %}
-          {% if object.large_company %}
-            <p class="rounded-md bg-[var(--bw-surface-muted)] px-3 py-2 font-bold text-[var(--bw-ink)]">Company-backed</p>
-          {% endif %}
-          {% if object.sponsored %}
-            <p class="rounded-md bg-[var(--bw-accent)] px-3 py-2 font-bold text-[var(--bw-ink)]">Featured listing</p>
-          {% endif %}
-        </div>
-      </section>
-
-      {% if object.technologies.all %}
-        <section class="bw-surface p-5">
-          <h2 class="text-sm font-black uppercase tracking-wider bw-muted">Tech stack</h2>
-          <div class="mt-4 flex flex-wrap gap-2">
-            {% for tech in object.technologies.all %}
-              <span class="inline-flex items-center rounded-md bg-{{ tech.color }}-100 px-3 py-1 text-sm font-black text-{{ tech.color }}-800">
-                {{ tech.name }}
-              </span>
-            {% endfor %}
-          </div>
-        </section>
-      {% endif %}
-    </aside>
   </div>
 </section>
 {% endblock content %}

--- a/templates/projects/submit-project.html
+++ b/templates/projects/submit-project.html
@@ -23,7 +23,7 @@
   <div class="bw-container">
     <p class="bw-kicker">Add to the showcase</p>
     <h1 class="bw-heading-lg mt-3">Submit a Django project</h1>
-    <p class="bw-lede mt-5">Share what you built so other Django developers can learn from it, use it, and send useful attention back to the maker.</p>
+    <p class="bw-lede mt-5">Share what you built so people using Django can learn from it, use it, and send useful attention back to the project.</p>
   </div>
 </section>
 

--- a/users/views.py
+++ b/users/views.py
@@ -10,8 +10,6 @@ from django.views.generic import CreateView, TemplateView, UpdateView
 from djstripe import models, settings as djstripe_settings
 
 from builtwithdjango.utils import get_builtwithdjango_logger
-from developers.forms import UpdateDeveloperForm
-from developers.models import Developer
 from newsletter.views import NewsletterSignupForm
 
 from .forms import CustomUserUpdateForm
@@ -41,18 +39,7 @@ class ProfileUpdateForm(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
     def get_initial(self):
         initial = super().get_initial()
         user = self.request.user
-        developer, _ = Developer.objects.get_or_create(user=user)
         models.Customer.get_or_create(subscriber=user)
-        initial["looking_for_a_job"] = developer.looking_for_a_job
-        initial["title"] = developer.title
-        initial["description"] = developer.description
-        initial["status"] = developer.status
-        initial["role"] = developer.role
-        initial["location"] = developer.location
-        initial["timezone"] = developer.timezone
-        initial["salary_expectation"] = developer.salary_expectation
-        initial["salary_cadence"] = developer.salary_cadence
-        initial["custom_capacity_field"] = developer.capacity.split(",")
         return initial
 
     def get_context_data(self, **kwargs):
@@ -61,11 +48,8 @@ class ProfileUpdateForm(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         user = self.request.user
         emailaddress = EmailAddress.objects.get_for_user(user, user.email)
         email_verified = emailaddress.verified
-        developer, created = Developer.objects.get_or_create(user=user)
 
         context["email_verified"] = email_verified
-        context["current_developer"] = developer
-        context["developer_form"] = UpdateDeveloperForm(initial=self.get_initial())
 
         return context
 


### PR DESCRIPTION
## Summary

Polishes the production UI regressions reported after the redesign shipped.

- Fixes project screenshot fitting on homepage/project surfaces so screenshots are contained and centered instead of cropped from the right.
- Removes the project detail sidebar that was stealing horizontal space, including the blank Project signals card, and moves tech stack content inline.
- Removes the blog post detail learning sidebar so posts have the full reading column.
- Replaces the TuxSEO ad with a solid-background Djass ad using copy and logo from djass.dev.
- Removes public Developers/Makers links and mentions from the main UI while keeping the existing routes/views available.

## Validation

- `mise exec uv@0.11.16 -- uvx djlint --profile=django --lint ...`
- `npm run build`
- `docker compose exec -T backend python manage.py check`
- `docker compose exec -T backend python manage.py test pages projects blog jobs users --keepdb`
- `mise exec uv@0.11.16 -- uvx black --check users/views.py`
- `mise exec uv@0.11.16 -- uvx isort --check-only users/views.py`
- `git diff --check`
- Playwright screenshots for home desktop/mobile and blog detail

Known existing warnings remain for Browserslist freshness, webpack asset size, duplicate `markdown_extras` template tags, and djstripe key configuration.
- Greptile: 5/5 on latest commit `e070dd3` with zero unresolved review threads