### PR TITLE
[Analytics] Fix PostHog activation and checkout events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ dsn=''
 
 # PostHog
 POSTHOG_ENABLED=false
+# The project API key is public; production falls back to the Built with Django key in settings.py.
 POSTHOG_API_KEY="your-posthog-project-api-key"
 POSTHOG_HOST="https://us.i.posthog.com"
 POSTHOG_UI_HOST="https://us.posthog.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 **Security** in case of vulnerabilities.
 
 ## Unreleased
+### Added
+- Restored production PostHog activation from the Built with Django public project key and added explicit checkout return/cancel analytics events for job, sponsored job, and Django Developers checkout flows.
+
 ### Changed
 - Simplified the landing page by removing the hero showcase, proof strip, and quick-link card band.
 - Expanded the home page project and guide sections to show six items and gave guides and jobs full-width sections.

--- a/builtwithdjango/analytics.py
+++ b/builtwithdjango/analytics.py
@@ -154,6 +154,31 @@ def capture_event(event, properties=None, distinct_id=None, groups=None):
         return None
 
 
+def capture_checkout_return(request, checkout_surface):
+    session_id = _sanitize_identifier(request.GET.get("session_id"))
+    status = _sanitize_identifier(request.GET.get("status"))
+
+    if session_id:
+        capture(
+            request,
+            "checkout returned",
+            properties={
+                "checkout_surface": checkout_surface,
+                "checkout_status": "success",
+                "stripe_checkout_session_id": session_id,
+            },
+        )
+    elif status == "failed":
+        capture(
+            request,
+            "checkout canceled",
+            properties={
+                "checkout_surface": checkout_surface,
+                "checkout_status": status,
+            },
+        )
+
+
 def get_request_properties(request):
     resolver_match = getattr(request, "resolver_match", None)
     properties = {

--- a/builtwithdjango/settings.py
+++ b/builtwithdjango/settings.py
@@ -501,11 +501,15 @@ if SENTRY_DSN and ENVIRONMENT == "prod":
         include_local_variables=True,
     )
 
-POSTHOG_API_KEY = env("POSTHOG_API_KEY", default="")
+BUILTWITHDJANGO_POSTHOG_PROJECT_API_KEY = "phc_Xvm3S1MGcMQXMHo2VJZabDhNJwmwbyhLedddpIU83Mo"
+POSTHOG_API_KEY = env(
+    "POSTHOG_API_KEY",
+    default=BUILTWITHDJANGO_POSTHOG_PROJECT_API_KEY if ENVIRONMENT == "prod" else "",
+)
 POSTHOG_HOST = env("POSTHOG_HOST", default="https://us.i.posthog.com")
 POSTHOG_UI_HOST = env("POSTHOG_UI_HOST", default="https://us.posthog.com")
 POSTHOG_PERSONAL_API_KEY = env("POSTHOG_PERSONAL_API_KEY", default="")
-POSTHOG_ENABLED = bool(POSTHOG_API_KEY) and env.bool("POSTHOG_ENABLED", default=False)
+POSTHOG_ENABLED = bool(POSTHOG_API_KEY) and env.bool("POSTHOG_ENABLED", default=ENVIRONMENT == "prod")
 POSTHOG_JS_DEFAULTS = "2026-01-30"
 
 posthog.api_key = POSTHOG_API_KEY

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -10,7 +10,7 @@ from django.views.generic import CreateView, DetailView, ListView, TemplateView
 from django_q.tasks import async_task
 from djstripe import models, settings as djstripe_settings
 
-from builtwithdjango.analytics import capture, email_domain, stable_hash
+from builtwithdjango.analytics import capture, capture_checkout_return, email_domain, stable_hash
 from newsletter.views import NewsletterSignupForm
 
 from .forms import PostJob
@@ -52,6 +52,7 @@ class JobDetailView(DetailView):
 
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
+        capture_checkout_return(request, "sponsored_job")
         capture(
             request,
             "job viewed",
@@ -139,6 +140,10 @@ class JobCreateView(CreateView):
 
 class ThankYouView(TemplateView):
     template_name = "jobs/post-job-thank-you.html"
+
+    def get(self, request, *args, **kwargs):
+        capture_checkout_return(request, "job")
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/pages/views.py
+++ b/pages/views.py
@@ -15,7 +15,7 @@ from django.views.generic import CreateView, RedirectView, TemplateView, UpdateV
 from django_q.tasks import async_task
 
 from blog.models import Post
-from builtwithdjango.analytics import capture, email_domain, stable_hash
+from builtwithdjango.analytics import capture, capture_checkout_return, email_domain, stable_hash
 from jobs.models import Job
 from jobs.tasks import get_latest_jobs_from_tj_alerts, send_sponsorship_request_email
 from newsletter.tasks import send_buttondown_newsletter
@@ -31,6 +31,10 @@ User = get_user_model()
 
 class HomeView(TemplateView):
     template_name = "pages/home.html"
+
+    def get(self, request, *args, **kwargs):
+        capture_checkout_return(request, "job")
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/developers/pricing-details.html
+++ b/templates/developers/pricing-details.html
@@ -96,7 +96,11 @@
             </div>
             <div class="mt-6">
               <div class="rounded-md shadow">
-                <a href="{% url 'checkout-django-devs' %}" class="flex items-center justify-center px-5 py-3 text-base font-medium text-white bg-gray-800 border border-transparent rounded-md hover:bg-gray-900">Get Access</a>
+                <a href="{% url 'checkout-django-devs' %}"
+                   class="flex items-center justify-center px-5 py-3 text-base font-medium text-white bg-gray-800 border border-transparent rounded-md hover:bg-gray-900"
+                   data-analytics-event="cta clicked"
+                   data-analytics-cta="django developers checkout"
+                   data-analytics-location="developers pricing">Get Access</a>
               </div>
             </div>
           </div>

--- a/users/views.py
+++ b/users/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse_lazy
 from django.views.generic import TemplateView, UpdateView
 from djstripe import models
 
-from builtwithdjango.analytics import capture
+from builtwithdjango.analytics import capture, capture_checkout_return
 
 from .forms import CustomUserUpdateForm
 from .models import CustomUser
@@ -28,6 +28,10 @@ class ProfileUpdateForm(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
 
     def get_object(self, queryset=None):
         return self.request.user
+
+    def get(self, request, *args, **kwargs):
+        capture_checkout_return(request, "django_developers")
+        return super().get(request, *args, **kwargs)
 
     def form_valid(self, form):
         models.Customer.get_or_create(subscriber=self.request.user)


### PR DESCRIPTION
## Summary
- Restore production PostHog activation using the Built with Django public project API key as the prod fallback
- Default PostHog on in production when a project key is available
- Add explicit checkout returned/canceled events for job, sponsored job, and Django Developers checkout paths
- Add analytics metadata to the Django Developers pricing CTA
- Update changelog and env example notes

## PostHog Dashboards Created
- BWD - Acquisition & Content: https://us.posthog.com/project/52923/dashboard/1630263
- BWD - Directory Engagement: https://us.posthog.com/project/52923/dashboard/1630264
- BWD - Revenue & Conversion: https://us.posthog.com/project/52923/dashboard/1630265
- BWD - Reliability & UX: https://us.posthog.com/project/52923/dashboard/1630266

## Verification
- python3 -m py_compile builtwithdjango/analytics.py builtwithdjango/settings.py jobs/views.py pages/views.py users/views.py
- git diff --check

## Notes
- Django test/check runs could not complete locally because this container cannot build pinned psycopg2 without pg_config. The code-level syntax and whitespace checks pass.