### PR TITLE
[Homepage] Show Latest Projects In 3x2 Grid

### DIFF
--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -32,7 +32,7 @@
       </div>
       <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent">Submit your project</a>
     </div>
-    <div class="bw-project-grid mt-8">
+    <div class="bw-project-grid mt-8 lg:grid-cols-3">
       {% for project in projects %}
         {% include "components/project-card.html" with site=project %}
       {% empty %}


### PR DESCRIPTION
## Summary

- Updates the homepage latest projects grid to use three columns on large screens.
- Keeps the existing six-project query, producing a 3 by 2 layout for the latest showcase.
- Leaves the all-projects index grid behavior unchanged.

## Validation

- Pre-commit ran `djLint` successfully during commit.
- `git diff --check` passed.
- Focused Django test could not run locally because this worktree is missing `builtwithdjango/.env` for Docker Compose.
