### PR TITLE
[Jobs] Email Imported Job Contacts About Promotion

### DIFF
--- a/jobs/tasks.py
+++ b/jobs/tasks.py
@@ -4,6 +4,8 @@ import cloudinary.uploader
 import requests
 from django.conf import settings
 from django.core.mail import send_mail
+from django.urls import reverse
+from django_q.tasks import async_task
 
 from builtwithdjango.sentry_utils import sentry_count, sentry_distribution, sentry_task_transaction
 from builtwithdjango.utils import get_builtwithdjango_logger
@@ -27,33 +29,61 @@ def notify_of_new_job(instance):
     )
 
 
-def send_sponsorship_request_email(job_instance):
+def queue_sponsorship_request_email(job_instance):
     """
-    Send an email to the job poster asking if they want to sponsor the job posting.
+    Queue an email asking the job owner if they want to promote the job.
     """
-    if not job_instance.email:
+    email = (job_instance.email or "").strip()
+    if not email:
+        logger.info(f"No email found for job {job_instance.id}, skipping sponsorship request")
+        return None
+
+    return async_task(
+        send_sponsorship_request_email,
+        job_instance.id,
+        task_name=f"send_sponsorship_email_job_{job_instance.id}",
+    )
+
+
+def send_sponsorship_request_email(job_id):
+    """
+    Send an email to the job poster asking if they want to promote the job posting.
+    """
+    try:
+        job_instance = Job.objects.get(pk=job_id)
+    except Job.DoesNotExist:
+        logger.warning(f"Job {job_id} does not exist, skipping sponsorship request")
+        return False
+
+    email = (job_instance.email or "").strip()
+    if not email:
         logger.info(f"No email found for job {job_instance.id}, skipping sponsorship request")
         return False
 
-    subject = f"Sponsor your Django job on Built with Django?"
+    subject = "Promote your Django job on Built with Django?"
 
     # Use SITE_URL from settings (works for local dev and production)
-    site_url = settings.SITE_URL
+    site_url = settings.SITE_URL.rstrip("/")
     job_url = f"{site_url}{job_instance.get_absolute_url()}"
-    sponsor_url = f"{site_url}/jobs/sponsor/{job_instance.id}/"
-    sponsor_options_url = f"{site_url}/sponsor/"
+    sponsor_url = f"{site_url}{reverse('sponsor_job_checkout', kwargs={'pk': job_instance.id})}"
+    sponsor_options_url = f"{site_url}{reverse('advertize')}"
 
     message = f"""Hey there,
 
-I just found your job on HackerNews and added it to Built with Django Job Board ({job_url}).
+I added your Django job to the Built with Django job board:
 
-Emailing you to ask if you want to sponsor that posting.
+{job_instance.title}
+{job_url}
 
-This would help you get a wider reach and help support Built with Django.
+Would you like to promote this job opening?
 
-Thanks for considering. If you are interested here is the link to purchase: {sponsor_url}
+Promoted jobs are highlighted on the job board and shared in the Built with Django newsletter.
 
-Here is the link to my other sponsoring options: {sponsor_options_url}
+You can promote this job here:
+{sponsor_url}
+
+You can also see the other sponsorship options here:
+{sponsor_options_url}
 
 Best,
 Rasul"""
@@ -62,11 +92,11 @@ Rasul"""
         send_mail(
             subject,
             message,
-            "Built with Django <rasul@builtwithdjango.com>",
-            [job_instance.email],
+            settings.DEFAULT_FROM_EMAIL,
+            [email],
             fail_silently=False,
         )
-        logger.info(f"Sponsorship request email sent successfully for job {job_instance.id} to {job_instance.email}")
+        logger.info(f"Sponsorship request email sent successfully for job {job_instance.id} to {email}")
         return True
     except Exception as e:
         logger.error(f"Failed to send sponsorship request email for job {job_instance.id}: {str(e)}")
@@ -148,7 +178,7 @@ def get_latest_jobs_from_tj_alerts():
                 new_job.save()
 
                 # Send sponsorship request email if job has an email address
-                # send_sponsorship_request_email(new_job)
+                queue_sponsorship_request_email(new_job)
 
                 count += 1
 

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -3,12 +3,12 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from django.template.loader import render_to_string
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from .models import Job
-from .tasks import get_latest_jobs_from_tj_alerts
+from .tasks import get_latest_jobs_from_tj_alerts, queue_sponsorship_request_email, send_sponsorship_request_email
 from .views import JobListView
 
 
@@ -104,16 +104,105 @@ class JobCheckoutTests(TestCase):
         ):
             response = self.client.get(reverse("sponsor_job_checkout", kwargs={"pk": job.pk}))
 
+        expected_success_url = f"http://testserver{reverse('job_thank_you')}?session_id={{CHECKOUT_SESSION_ID}}"
+        expected_cancel_url = f"http://testserver{job.get_absolute_url()}?status=failed"
+
         self.assertEqual(response.status_code, 303)
         self.assertEqual(response["Location"], checkout_session.url)
         get_price.assert_called_once_with("job")
-        create_session.assert_called_once()
-        self.assertEqual(create_session.call_args.kwargs["metadata"], {"pk": str(job.pk), "price_id": price_id})
+        create_session.assert_called_once_with(
+            success_url=expected_success_url,
+            cancel_url=expected_cancel_url,
+            mode="payment",
+            line_items=[
+                {
+                    "quantity": 1,
+                    "price": price_id,
+                }
+            ],
+            allow_promotion_codes=True,
+            automatic_tax={"enabled": True},
+            metadata={"pk": str(job.pk), "price_id": price_id},
+        )
         capture.assert_called_once()
 
 
+class JobSponsorshipEmailTaskTests(TestCase):
+    @override_settings(
+        SITE_URL="https://builtwithdjango.com",
+        DEFAULT_FROM_EMAIL="Built with Django <rasul@builtwithdjango.com>",
+    )
+    @patch("jobs.tasks.send_mail")
+    def test_send_sponsorship_request_email_sends_promotion_email(self, send_mail):
+        job = Job.objects.create(
+            title="Senior Django Developer",
+            listing_url="https://example.com/jobs/senior-django-developer",
+            company_name="Example Co",
+            email="hiring@example.com",
+        )
+
+        sent = send_sponsorship_request_email(job.id)
+
+        self.assertTrue(sent)
+        send_mail.assert_called_once()
+        subject, message, from_email, recipients = send_mail.call_args.args
+        self.assertEqual(subject, "Promote your Django job on Built with Django?")
+        self.assertEqual(from_email, "Built with Django <rasul@builtwithdjango.com>")
+        self.assertEqual(recipients, ["hiring@example.com"])
+        self.assertIn("I added your Django job to the Built with Django job board", message)
+        self.assertIn(f"https://builtwithdjango.com{job.get_absolute_url()}", message)
+        expected_sponsor_path = reverse("sponsor_job_checkout", kwargs={"pk": job.id})
+        self.assertIn(f"https://builtwithdjango.com{expected_sponsor_path}", message)
+        self.assertIn("shared in the Built with Django newsletter", message)
+        self.assertEqual(send_mail.call_args.kwargs, {"fail_silently": False})
+
+    @patch("jobs.tasks.send_mail")
+    def test_send_sponsorship_request_email_skips_jobs_without_email(self, send_mail):
+        job = Job.objects.create(
+            title="Django Developer",
+            listing_url="https://example.com/jobs/django-developer",
+            company_name="Example Co",
+        )
+
+        sent = send_sponsorship_request_email(job.id)
+
+        self.assertFalse(sent)
+        send_mail.assert_not_called()
+
+    @patch("jobs.tasks.async_task")
+    def test_queue_sponsorship_request_email_queues_job_id(self, async_task):
+        async_task.return_value = "task-id"
+        job = Job.objects.create(
+            title="Django Developer",
+            listing_url="https://example.com/jobs/django-developer",
+            company_name="Example Co",
+            email="hiring@example.com",
+        )
+
+        task_id = queue_sponsorship_request_email(job)
+
+        self.assertEqual(task_id, "task-id")
+        task_function, job_id = async_task.call_args.args
+        self.assertIs(task_function, send_sponsorship_request_email)
+        self.assertEqual(job_id, job.id)
+        self.assertEqual(async_task.call_args.kwargs, {"task_name": f"send_sponsorship_email_job_{job.id}"})
+
+    @patch("jobs.tasks.async_task")
+    def test_queue_sponsorship_request_email_skips_jobs_without_email(self, async_task):
+        job = Job.objects.create(
+            title="Django Developer",
+            listing_url="https://example.com/jobs/django-developer",
+            company_name="Example Co",
+        )
+
+        task_id = queue_sponsorship_request_email(job)
+
+        self.assertIsNone(task_id)
+        async_task.assert_not_called()
+
+
 class JobImportTaskTests(TestCase):
-    def test_get_latest_jobs_from_tj_alerts_imports_new_jobs_and_skips_duplicates(self):
+    def test_get_latest_jobs_from_tj_alerts_imports_new_jobs_skips_duplicates_and_queues_email(self):
         submitted_at = timezone.now()
         Job.objects.create(
             title="Existing Django role",
@@ -161,6 +250,7 @@ class JobImportTaskTests(TestCase):
                 "jobs.tasks.cloudinary.uploader.upload",
                 return_value={"version": "1", "public_id": "logos/new"},
             ) as upload,
+            patch("jobs.tasks.queue_sponsorship_request_email") as queue_sponsorship_email,
         ):
             result = get_latest_jobs_from_tj_alerts()
 
@@ -171,3 +261,37 @@ class JobImportTaskTests(TestCase):
         self.assertTrue(new_job.approved)
         self.assertEqual(get.call_args_list[0].kwargs["timeout"], 30)
         upload.assert_called_once()
+        queue_sponsorship_email.assert_called_once_with(new_job)
+
+    @patch("jobs.tasks.queue_sponsorship_request_email")
+    @patch("jobs.tasks.requests.get")
+    def test_get_latest_jobs_from_tj_alerts_delegates_sponsorship_email_skip_without_email(
+        self, requests_get, queue_sponsorship_request_email
+    ):
+        job_response = Mock()
+        job_response.json.return_value = {
+            "jobs": [
+                {
+                    "id": "tj-2",
+                    "title": ["Django Developer"],
+                    "company_url": "",
+                    "emails": [],
+                    "submitted_datetime": timezone.now(),
+                    "description": "Build Django apps.",
+                    "min_salary": None,
+                    "max_salary": None,
+                    "is_remote": True,
+                    "locations": "Remote",
+                    "company_name": "Example Co",
+                }
+            ]
+        }
+        healthcheck_response = Mock()
+        requests_get.side_effect = [job_response, healthcheck_response]
+
+        result = get_latest_jobs_from_tj_alerts()
+
+        self.assertEqual(result, "1 jobs were created.")
+        job = Job.objects.get(external_id="tj-2", source="gettjalerts.com")
+        self.assertEqual(job.email, "")
+        queue_sponsorship_request_email.assert_called_once_with(job)

--- a/pages/views.py
+++ b/pages/views.py
@@ -17,7 +17,7 @@ from django_q.tasks import async_task
 from blog.models import Post
 from builtwithdjango.analytics import capture, capture_checkout_return, email_domain, stable_hash
 from jobs.models import Job
-from jobs.tasks import get_latest_jobs_from_tj_alerts, send_sponsorship_request_email
+from jobs.tasks import get_latest_jobs_from_tj_alerts, queue_sponsorship_request_email
 from newsletter.tasks import send_buttondown_newsletter
 from newsletter.views import NewsletterSignupForm
 from podcast.models import Episode
@@ -217,7 +217,11 @@ class SendSponsorshipEmailView(UserPassesTestMixin, View):
             return HttpResponseRedirect(reverse("admin-panel"))
 
         # Queue the async task
-        async_task(send_sponsorship_request_email, latest_job, task_name=f"send_sponsorship_email_job_{latest_job.id}")
+        task_id = queue_sponsorship_request_email(latest_job)
+        if not task_id:
+            messages.error(request, f"No email address found for job: {latest_job.title}.")
+            return HttpResponseRedirect(reverse("admin-panel"))
+
         capture(
             request,
             "admin sponsorship email queued",


### PR DESCRIPTION
## Summary
- Queue a Django-Q task after imported TJ Alerts jobs are saved, with the worker receiving only the saved job id.
- Send a promotion email that links to the job detail page, the job promotion checkout, and sponsorship options.
- Verify the sponsor checkout route creates a Stripe Checkout Session and redirects to Stripe with HTTP 303.
- Reuse the same queue helper from the admin sponsorship email action and add tests for send/skip/import behavior.

## Validation
- `PATH="/opt/homebrew/opt/libpq/bin:$PATH" mise exec uv@0.11.16 -- uv run --python 3.11 --with-requirements requirements-dev.txt pytest jobs` (`10 passed`)
- `python3 -m py_compile jobs/tasks.py jobs/tests.py jobs/views.py pages/views.py`
- `git diff --check`
- Pre-commit hooks passed: end-of-file fixer, trailing whitespace, black, isort, poetry-export
- GitHub CI: Python 3.11, Python 3.13, and Frontend passed on `1049617`
- Greptile: 5/5 confidence on `1049617`, 0 unresolved review threads