### PR TITLE
[Footer] Polish Django Webring

### DIFF
--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -715,37 +715,29 @@
     width: min(100% - 2rem, 72rem);
     margin-inline: auto;
     border-top: 1px solid oklch(35% 0.035 156);
-    padding-top: clamp(1.4rem, 4vw, 2.5rem);
-    padding-bottom: clamp(7.25rem, 13vw, 9.5rem);
+    padding-top: clamp(1.6rem, 4vw, 2.7rem);
+    padding-bottom: clamp(6.75rem, 12vw, 8.75rem);
   }
 
   .bw-webring-panel {
     display: grid;
-    gap: 1.25rem;
+    gap: clamp(1.25rem, 4vw, 2.6rem);
     align-items: center;
-    border: 1px solid oklch(35% 0.045 151);
-    border-radius: var(--bw-radius);
-    background:
-      linear-gradient(135deg, oklch(18% 0.045 151), oklch(13% 0.035 151)),
-      var(--bw-ink);
-    padding: clamp(1rem, 4vw, 1.4rem);
-    box-shadow: inset 0 1px 0 oklch(100% 0.01 118 / 0.08);
   }
 
   @media (min-width: 768px) {
     .bw-webring-panel {
-      grid-template-columns: minmax(14rem, 0.9fr) minmax(0, 1.25fr);
-      gap: clamp(1.5rem, 5vw, 3rem);
+      grid-template-columns: minmax(16rem, 0.85fr) minmax(0, 1.15fr);
     }
   }
 
   .bw-webring-copy {
-    max-width: 28rem;
+    max-width: 32rem;
   }
 
   .bw-webring-label {
     color: var(--bw-accent);
-    font-size: 0.74rem;
+    font-size: 0.72rem;
     font-weight: 900;
     letter-spacing: 0.06em;
     line-height: 1;
@@ -755,23 +747,28 @@
   .bw-webring-copy h2 {
     margin-top: 0.7rem;
     color: oklch(96% 0.025 126);
-    font-size: clamp(1.65rem, 4vw, 2.35rem);
+    font-size: clamp(1.55rem, 3.2vw, 2.2rem);
     font-weight: 900;
-    line-height: 0.98;
+    line-height: 1;
   }
 
   .bw-webring-copy p:not(.bw-webring-label) {
     margin-top: 0.85rem;
-    color: oklch(78% 0.03 126);
+    max-width: 30rem;
+    color: oklch(77% 0.03 126);
     font-size: 0.95rem;
     line-height: 1.6;
   }
 
   .bw-webring-widget {
     min-width: 0;
+    border: 1px solid oklch(34% 0.04 151);
     border-radius: var(--bw-radius);
-    background: oklch(11% 0.03 151);
-    padding: clamp(0.9rem, 3vw, 1.2rem);
+    background:
+      linear-gradient(180deg, oklch(16% 0.035 151), oklch(12.5% 0.03 151)),
+      oklch(14% 0.03 151);
+    box-shadow: inset 0 1px 0 oklch(100% 0.01 118 / 0.07);
+    padding: clamp(0.85rem, 3vw, 1rem);
   }
 
   .bw-webring-widget webring-css {

--- a/templates/base.html
+++ b/templates/base.html
@@ -452,13 +452,13 @@
         </div>
       </div>
       <div class="bw-webring-shell">
-        <div class="bw-webring-panel" aria-labelledby="bw-webring-title">
+        <div class="bw-webring-panel" role="region" aria-labelledby="bw-webring-title">
           <div class="bw-webring-copy">
             <p class="bw-webring-label">Django Webring</p>
             <h2 id="bw-webring-title">Independent Django sites, one stop away</h2>
             <p>Follow the ring to visit a previous, random, or next member site from the Django community.</p>
           </div>
-          <div class="bw-webring-widget" aria-label="Django Webring navigation">
+          <div class="bw-webring-widget" role="navigation" aria-label="Django Webring navigation">
             <webring-css site="https://builtwithdjango.com"></webring-css>
           </div>
         </div>
@@ -491,8 +491,18 @@
               content.querySelectorAll('a').forEach((link) => {
                 const currentLabel = link.textContent.trim();
                 if (labels[currentLabel]) {
+                  const destinationHost = (() => {
+                    try {
+                      return new URL(link.href).hostname.replace(/^www\./, '');
+                    } catch (error) {
+                      return labels[currentLabel];
+                    }
+                  })();
+                  const siteName = link.getAttribute('title') || destinationHost;
+
                   link.textContent = labels[currentLabel];
-                  link.setAttribute('aria-label', `${labels[currentLabel]} Django Webring site`);
+                  link.dataset.webringSite = siteName;
+                  link.setAttribute('aria-label', `${labels[currentLabel]} Django Webring site: ${siteName}`);
                 }
               });
 
@@ -588,7 +598,7 @@
                   width: 100% !important;
                   overflow: hidden !important;
                   color: oklch(70% 0.025 126) !important;
-                  content: attr(title) !important;
+                  content: attr(data-webring-site) !important;
                   font-size: 0.7rem !important;
                   font-weight: 750 !important;
                   line-height: 1.1 !important;

--- a/templates/base.html
+++ b/templates/base.html
@@ -452,13 +452,13 @@
         </div>
       </div>
       <div class="bw-webring-shell">
-        <div class="bw-webring-panel">
+        <div class="bw-webring-panel" aria-labelledby="bw-webring-title">
           <div class="bw-webring-copy">
-            <p class="bw-webring-label">Community ring</p>
-            <h2>A small Django neighborhood</h2>
-            <p>Built with Django is part of a small loop of independent Django sites. Follow the ring to find another corner of the community.</p>
+            <p class="bw-webring-label">Django Webring</p>
+            <h2 id="bw-webring-title">Independent Django sites, one stop away</h2>
+            <p>Follow the ring to visit a previous, random, or next member site from the Django community.</p>
           </div>
-          <div class="bw-webring-widget">
+          <div class="bw-webring-widget" aria-label="Django Webring navigation">
             <webring-css site="https://builtwithdjango.com"></webring-css>
           </div>
         </div>
@@ -469,9 +469,44 @@
             if (!host) return;
 
             const styleId = 'builtwithdjango-webring-restyle';
+            const normalizeContent = () => {
+              const root = host.shadowRoot;
+              if (!root) return false;
+
+              const content = root.querySelector('.django-webring__content');
+              if (!content || !content.children.length) return false;
+
+              const subheading = content.querySelector('h2');
+              if (subheading && subheading.textContent.trim() === 'The Great Django Webring') {
+                subheading.textContent = 'Choose a route';
+              }
+
+              const labels = {
+                '[Prev]': 'Previous',
+                '[Random]': 'Random',
+                '[Next]': 'Next',
+                '[Visit a member site]': 'Visit a member site',
+              };
+
+              content.querySelectorAll('a').forEach((link) => {
+                const currentLabel = link.textContent.trim();
+                if (labels[currentLabel]) {
+                  link.textContent = labels[currentLabel];
+                  link.setAttribute('aria-label', `${labels[currentLabel]} Django Webring site`);
+                }
+              });
+
+              return true;
+            };
+
             const applyStyle = () => {
               if (!host.shadowRoot) return false;
-              if (host.shadowRoot.getElementById(styleId)) return true;
+              if (!host.bwdWebringObserver) {
+                host.bwdWebringObserver = new MutationObserver(normalizeContent);
+                host.bwdWebringObserver.observe(host.shadowRoot, { childList: true, subtree: true });
+              }
+              const contentReady = normalizeContent();
+              if (host.shadowRoot.getElementById(styleId)) return contentReady;
 
               const style = document.createElement('style');
               style.id = styleId;
@@ -488,7 +523,7 @@
                   background: transparent !important;
                   box-shadow: none !important;
                   padding: 0 !important;
-                  color: oklch(91% 0.025 126) !important;
+                  color: oklch(90% 0.025 126) !important;
                   font-family: inherit !important;
                   text-align: left !important;
                 }
@@ -499,46 +534,47 @@
 
                 .django-webring__content {
                   display: grid !important;
-                  gap: 0.8rem !important;
+                  gap: 0.85rem !important;
                 }
 
                 .django-webring__content h1 {
-                  margin: 0 !important;
-                  color: oklch(96% 0.025 126) !important;
-                  font-size: clamp(1.1rem, 3vw, 1.45rem) !important;
-                  font-weight: 900 !important;
-                  line-height: 1.05 !important;
+                  display: none !important;
                 }
 
                 .django-webring__content h2 {
                   margin: 0 !important;
-                  color: oklch(78% 0.12 92) !important;
-                  font-size: 0.95rem !important;
-                  font-weight: 850 !important;
-                  line-height: 1.35 !important;
+                  color: oklch(83% 0.055 126) !important;
+                  font-size: 0.82rem !important;
+                  font-weight: 900 !important;
+                  letter-spacing: 0 !important;
+                  line-height: 1.2 !important;
                 }
 
                 .django-webring__content p {
+                  display: grid !important;
+                  grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+                  gap: 0.55rem !important;
                   margin: 0 !important;
-                  color: oklch(78% 0.03 126) !important;
-                  font-size: 0.92rem !important;
-                  line-height: 1.55 !important;
                 }
 
                 .django-webring__content a {
                   display: inline-flex !important;
-                  min-height: 2.45rem !important;
-                  align-items: center !important;
+                  min-width: 0 !important;
+                  min-height: 3.25rem !important;
+                  flex-direction: column !important;
+                  align-items: flex-start !important;
                   justify-content: center !important;
-                  margin: 0.25rem 0.35rem 0 0 !important;
-                  border: 1px solid oklch(50% 0.06 150) !important;
+                  gap: 0.18rem !important;
+                  margin: 0 !important;
+                  border: 1px solid oklch(43% 0.05 150) !important;
                   border-radius: 8px !important;
-                  background: oklch(18% 0.035 151) !important;
-                  color: oklch(94% 0.025 126) !important;
-                  padding: 0.58rem 0.8rem !important;
-                  font-size: 0.88rem !important;
-                  font-weight: 850 !important;
-                  line-height: 1 !important;
+                  background: oklch(17% 0.032 151) !important;
+                  color: oklch(93% 0.025 126) !important;
+                  padding: 0.7rem 0.78rem !important;
+                  overflow: hidden !important;
+                  font-size: 0.86rem !important;
+                  font-weight: 900 !important;
+                  line-height: 1.05 !important;
                   text-decoration: none !important;
                   transition:
                     background-color 160ms cubic-bezier(0.22, 1, 0.36, 1),
@@ -547,12 +583,30 @@
                     transform 160ms cubic-bezier(0.22, 1, 0.36, 1) !important;
                 }
 
+                .django-webring__content a::after {
+                  display: block !important;
+                  width: 100% !important;
+                  overflow: hidden !important;
+                  color: oklch(70% 0.025 126) !important;
+                  content: attr(title) !important;
+                  font-size: 0.7rem !important;
+                  font-weight: 750 !important;
+                  line-height: 1.1 !important;
+                  text-overflow: ellipsis !important;
+                  white-space: nowrap !important;
+                }
+
                 .django-webring__content a:hover,
                 .django-webring__content a:focus-visible {
-                  border-color: oklch(79% 0.16 92) !important;
-                  background: oklch(78% 0.17 92) !important;
-                  color: oklch(16% 0.04 151) !important;
+                  border-color: oklch(76% 0.15 92) !important;
+                  background: oklch(23% 0.052 151) !important;
+                  color: oklch(97% 0.018 116) !important;
                   transform: translateY(-1px) !important;
+                }
+
+                .django-webring__content a:hover::after,
+                .django-webring__content a:focus-visible::after {
+                  color: oklch(83% 0.07 92) !important;
                 }
 
                 @media (max-width: 600px) {
@@ -560,14 +614,17 @@
                     gap: 0.7rem !important;
                   }
 
+                  .django-webring__content p {
+                    grid-template-columns: 1fr !important;
+                  }
+
                   .django-webring__content a {
                     width: 100% !important;
-                    margin-right: 0 !important;
                   }
                 }
               `;
               host.shadowRoot.appendChild(style);
-              return true;
+              return contentReady;
             };
 
             let attempts = 0;


### PR DESCRIPTION
## Summary
- Simplifies the Django Webring footer so it sits in the footer as a single section instead of a nested framed panel.
- Rewrites the web ring copy and adds accessible labels/roles for the section and widget navigation.
- Restyles the third-party shadow DOM widget into compact route controls and normalizes its bracketed labels after async content loads.
- Addresses Greptile feedback by adding effective ARIA roles and replacing `attr(title)` subtitles with explicit `data-webring-site` values.

## Validation
- `npm run build` passes locally. Webpack still reports the existing asset and entrypoint size warnings.
- `git diff --check` passes.
- Commit hook ran `djLint` successfully.
- GitHub CI passes: Frontend, Python 3.11, Python 3.13.
- Claude review passes.
- Greptile review: 5/5 confidence, all Greptile review threads resolved.
