### PR TITLE
[Jobs] Clarify Optional Sponsored Payment

### DIFF
--- a/templates/jobs/post-job.html
+++ b/templates/jobs/post-job.html
@@ -4,16 +4,16 @@
 
 {% block meta %}
     <title>Post a Django Job | Built with Django</title>
-    <meta name="description" content="Post a Django job for the Built with Django community." />
+    <meta name="description" content="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." />
     <link rel="canonical" href="https://{{ request.get_host }}/jobs/new" />
     <meta property="og:title" content="Post a Django Job | Built with Django" />
     <meta property="og:url" content="https://{{ request.get_host }}/jobs/new" />
-    <meta property="og:description" content="Post a Django job for the Built with Django community." />
+    <meta property="og:description" content="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." />
     <meta property="og:image" content="{% static 'vendors/images/logo.png' %}" />
     <meta name="twitter:creator" content="@rasulkireev" />
     <meta name="twitter:site" content="@builtwithdjango" />
     <meta name="twitter:title" content="Post a Django Job | Built with Django" />
-    <meta name="twitter:description" content="Post a Django job for the Built with Django community." />
+    <meta name="twitter:description" content="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." />
     <meta name="twitter:image" content="{% static 'vendors/images/logo.png' %}" />
 {% endblock meta %}
 

--- a/templates/jobs/post-job.html
+++ b/templates/jobs/post-job.html
@@ -22,7 +22,7 @@
   <div class="bw-container">
     <p class="bw-kicker">Reach Django builders</p>
     <h1 class="bw-heading-lg mt-3">Post a Django job</h1>
-    <p class="bw-lede mt-5">Share the core role details. The listing URL lets us fill in the rest and send people to your canonical job post.</p>
+    <p class="bw-lede mt-5">Share the core role details. After submitting, you'll be taken to a payment page for an optional sponsored post. You can skip sponsorship; your job will still be added to the job board.</p>
   </div>
 </section>
 
@@ -82,7 +82,7 @@
       <h2 class="text-xl font-black">Why post here?</h2>
       <ul class="mt-4 grid gap-3 text-sm leading-6 bw-muted">
         <li><strong class="text-[var(--bw-ink)]">Django-specific audience.</strong> Reach people who already care about this stack.</li>
-        <li><strong class="text-[var(--bw-ink)]">Simple submission.</strong> The listing URL keeps the source of truth on your site.</li>
+        <li><strong class="text-[var(--bw-ink)]">Simple submission.</strong> The listing URL keeps the source of truth on your site, and sponsorship is optional after you submit.</li>
         <li><strong class="text-[var(--bw-ink)]">Community context.</strong> Jobs sit alongside projects, guides, and practical community resources.</li>
       </ul>
     </aside>


### PR DESCRIPTION
## Summary
- Clarify that submitting the job form redirects to an optional sponsored-post payment page.
- Make it explicit that skipping sponsorship still leaves the job on the job board.
- Keep the page meta, Open Graph, and Twitter descriptions aligned with the new sponsorship messaging.

## Testing
- git diff --check origin/master...HEAD
- Commit hooks ran and passed, including djLint for Django templates.
- GitHub CI passed: Frontend, Python 3.11, Python 3.13, and claude-review.

## Notes
- Local Django checks are blocked in this worktree because Python/Django is not installed and Docker requires builtwithdjango/.env.