### PR TITLE
[SEO] Standardize Metadata and Structured Data

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -9,7 +9,7 @@ from .models import Post
 class PostListView(ListView):
     model = Post
     template_name = "blog/all_posts.html"
-    queryset = Post.objects.filter(type="TUTORIAL")
+    queryset = Post.objects.filter(type=Post.TUTORIAL, status=Post.PUBLISHED)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -33,6 +33,9 @@ class ArticleListView(ListView):
 class PostDetailView(DetailView):
     model = Post
     template_name = "blog/post_detail.html"
+
+    def get_queryset(self):
+        return Post.objects.filter(status=Post.PUBLISHED)
 
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)

--- a/builtwithdjango/settings.py
+++ b/builtwithdjango/settings.py
@@ -269,6 +269,7 @@ TEMPLATES = [
         "OPTIONS": {
             "builtins": [
                 "django_component.templatetags",
+                "pages.templatetags.seo",
             ],
             "context_processors": [
                 "django.template.context_processors.debug",

--- a/builtwithdjango/sitemaps.py
+++ b/builtwithdjango/sitemaps.py
@@ -81,7 +81,13 @@ sitemaps = {
     ),
     "makers": GenericSitemap(
         {
-            "queryset": Maker.objects.filter(projects__published=True).order_by("pk").distinct(),
+            "queryset": Maker.objects.filter(
+                projects__published=True,
+                projects__active=True,
+                projects__might_be_spam=False,
+            )
+            .order_by("pk")
+            .distinct(),
             "date_field": "updated_date",
         },
         priority=0.7,

--- a/builtwithdjango/sitemaps.py
+++ b/builtwithdjango/sitemaps.py
@@ -3,7 +3,9 @@ from django.contrib.sitemaps import GenericSitemap
 from django.urls import reverse
 
 from blog.models import Post
+from developers.models import Developer
 from jobs.models import Job
+from makers.models import Maker
 from podcast.models import Episode
 from projects.models import Project
 
@@ -23,11 +25,18 @@ class StaticViewSitemap(sitemaps.Sitemap):
         return [
             "home",
             "uses",
+            "support",
+            "advertize",
             "submit_project",
             "projects",
+            "makers",
+            "developers",
             "podcast_episodes",
+            "blog",
+            "articles",
             "jobs",
             "post_job",
+            "newsletter_home",
             "generate_django_secret_page",
             "format_html_view",
         ]
@@ -46,10 +55,14 @@ class StaticViewSitemap(sitemaps.Sitemap):
 
 sitemaps = {
     "static": StaticViewSitemap,
-    "blog": GenericSitemap({"queryset": Post.objects.all(), "date_field": "created"}, priority=0.9, protocol="https"),
+    "blog": GenericSitemap(
+        {"queryset": Post.objects.filter(status=Post.PUBLISHED), "date_field": "created"},
+        priority=0.9,
+        protocol="https",
+    ),
     "projects": GenericSitemap(
         {
-            "queryset": Project.objects.filter(published=True),
+            "queryset": Project.objects.filter(published=True, active=True, might_be_spam=False),
             "date_field": "date_added",
         },
         priority=0.85,
@@ -65,5 +78,21 @@ sitemaps = {
     ),
     "podcast": GenericSitemap(
         {"queryset": Episode.objects.all(), "date_field": "created_datetime"}, priority=0.8, protocol="https"
+    ),
+    "makers": GenericSitemap(
+        {
+            "queryset": Maker.objects.filter(projects__published=True).order_by("pk").distinct(),
+            "date_field": "updated_date",
+        },
+        priority=0.7,
+        protocol="https",
+    ),
+    "developers": GenericSitemap(
+        {
+            "queryset": Developer.objects.filter(looking_for_a_job=True),
+            "date_field": "modified",
+        },
+        priority=0.7,
+        protocol="https",
     ),
 }

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -1,7 +1,12 @@
+import json
+import tempfile
+from pathlib import Path
+
 from django.contrib.auth import get_user_model
 from django.template import Context, Template
 from django.template.loader import render_to_string
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from webpack_boilerplate import utils as webpack_utils
 
 from blog.models import Post
 from builtwithdjango.sitemaps import StaticViewSitemap, sitemaps
@@ -101,6 +106,39 @@ class SeoSitemapTests(TestCase):
 
 class SeoPageRenderTests(TestCase):
     def setUp(self):
+        self.webpack_manifest_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.webpack_manifest_dir.cleanup)
+
+        manifest_path = Path(self.webpack_manifest_dir.name) / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "entrypoints": {
+                        "hotwire": {
+                            "assets": {
+                                "js": ["/static/js/hotwire.js"],
+                                "css": ["/static/css/hotwire.css"],
+                            },
+                        },
+                    },
+                    "css/hotwire.css": "/static/css/hotwire.css",
+                    "js/hotwire.js": "/static/js/hotwire.js",
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        webpack_utils._loaders.clear()
+        self.webpack_settings = self.settings(
+            WEBPACK_LOADER={
+                "CACHE": False,
+                "MANIFEST_FILE": str(manifest_path),
+            },
+        )
+        self.webpack_settings.enable()
+        self.addCleanup(self.webpack_settings.disable)
+        self.addCleanup(webpack_utils._loaders.clear)
+
         self.author = get_user_model().objects.create_user(
             username="page-author",
             email="page-author@example.com",

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -12,6 +12,7 @@ from blog.models import Post
 from builtwithdjango.sitemaps import StaticViewSitemap, sitemaps
 from developers.models import Developer
 from jobs.models import Job
+from makers.models import Maker
 from projects.models import Project
 
 
@@ -50,6 +51,14 @@ class SeoTemplateTagTests(SimpleTestCase):
 
         self.assertEqual(html, '"name": "Django \\"Guide\\"\\nTest"')
 
+    def test_json_ld_filter_escapes_script_breakout_characters(self):
+        template = Template("{{ value|json_ld }}")
+        html = template.render(Context({"value": "</script><script>alert(1)</script>&"}))
+
+        self.assertNotIn("</script>", html)
+        self.assertIn("\\u003C/script\\u003E", html)
+        self.assertIn("\\u0026", html)
+
 
 class SeoSitemapTests(TestCase):
     def test_static_sitemap_includes_public_index_pages(self):
@@ -83,6 +92,10 @@ class SeoSitemapTests(TestCase):
             content="Content",
             status=Post.DRAFT,
         )
+        visible_maker = Maker.objects.create(first_name="Visible", last_name="Maker", slug="visible-maker")
+        spam_maker = Maker.objects.create(first_name="Spam", last_name="Maker", slug="spam-maker")
+        inactive_maker = Maker.objects.create(first_name="Inactive", last_name="Maker", slug="inactive-maker")
+
         visible_project = Project.objects.create(
             title="Visible Project",
             url="https://visible.example.com",
@@ -90,6 +103,7 @@ class SeoSitemapTests(TestCase):
             published=True,
             active=True,
             might_be_spam=False,
+            maker=visible_maker,
         )
         Project.objects.create(
             title="Spam Project",
@@ -98,10 +112,21 @@ class SeoSitemapTests(TestCase):
             published=True,
             active=True,
             might_be_spam=True,
+            maker=spam_maker,
+        )
+        Project.objects.create(
+            title="Inactive Project",
+            url="https://inactive.example.com",
+            short_description="Hidden from sitemap.",
+            published=True,
+            active=False,
+            might_be_spam=False,
+            maker=inactive_maker,
         )
 
         self.assertEqual(list(sitemaps["blog"].items()), [published_post])
         self.assertEqual(list(sitemaps["projects"].items()), [visible_project])
+        self.assertEqual(list(sitemaps["makers"].items()), [visible_maker])
 
 
 class SeoPageRenderTests(TestCase):
@@ -201,5 +226,8 @@ class SeoPageRenderTests(TestCase):
 
         self.assertEqual(job_response.status_code, 200)
         self.assertEqual(developer_response.status_code, 200)
-        self.assertIn('"@type": "JobPosting"', job_response.content.decode())
+        job_html = job_response.content.decode()
+        self.assertIn('<meta property="og:type" content="website" />', job_html)
+        self.assertIn('"@type": "JobPosting"', job_html)
+        self.assertNotIn('"address": ""', job_html)
         self.assertIn('"@type": "Person"', developer_response.content.decode())

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -1,0 +1,167 @@
+from django.contrib.auth import get_user_model
+from django.template import Context, Template
+from django.template.loader import render_to_string
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+
+from blog.models import Post
+from builtwithdjango.sitemaps import StaticViewSitemap, sitemaps
+from developers.models import Developer
+from jobs.models import Job
+from projects.models import Project
+
+
+class SeoTemplateTagTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(SITE_URL="https://builtwithdjango.com")
+    def test_absolute_url_uses_site_url_for_relative_paths(self):
+        template = Template("{% absolute_url '/media/share.png' %}")
+        html = template.render(Context({"request": self.factory.get("/ignored/")}))
+
+        self.assertEqual(html, "https://builtwithdjango.com/media/share.png")
+
+    @override_settings(SITE_URL="https://builtwithdjango.com")
+    def test_seo_meta_outputs_canonical_and_absolute_share_image(self):
+        request = self.factory.get("/ignored/?utm_source=test")
+        html = render_to_string(
+            "components/seo_meta.html",
+            {
+                "title": "Django Projects | Built with Django",
+                "description": "Discover projects built with Django.",
+                "canonical_path": "/projects/",
+                "image": "/media/share.png",
+            },
+            request=request,
+        )
+
+        self.assertIn('<link rel="canonical" href="https://builtwithdjango.com/projects/" />', html)
+        self.assertIn('<meta property="og:image" content="https://builtwithdjango.com/media/share.png" />', html)
+        self.assertIn('<meta name="twitter:image" content="https://builtwithdjango.com/media/share.png" />', html)
+
+    def test_json_ld_filter_outputs_valid_json_string(self):
+        template = Template('"name": {{ value|json_ld }}')
+        html = template.render(Context({"value": 'Django "Guide"\nTest'}))
+
+        self.assertEqual(html, '"name": "Django \\"Guide\\"\\nTest"')
+
+
+class SeoSitemapTests(TestCase):
+    def test_static_sitemap_includes_public_index_pages(self):
+        items = StaticViewSitemap().items()
+
+        self.assertIn("projects", items)
+        self.assertIn("makers", items)
+        self.assertIn("developers", items)
+        self.assertIn("articles", items)
+        self.assertIn("newsletter_home", items)
+
+    def test_content_sitemaps_only_include_indexable_records(self):
+        author = get_user_model().objects.create_user(
+            username="seo-author",
+            email="seo-author@example.com",
+            password="test-pass",
+        )
+        published_post = Post.objects.create(
+            title="Published Guide",
+            description="Visible in sitemap.",
+            author=author,
+            slug="published-guide",
+            content="Content",
+            status=Post.PUBLISHED,
+        )
+        Post.objects.create(
+            title="Draft Guide",
+            description="Hidden from sitemap.",
+            author=author,
+            slug="draft-guide",
+            content="Content",
+            status=Post.DRAFT,
+        )
+        visible_project = Project.objects.create(
+            title="Visible Project",
+            url="https://visible.example.com",
+            short_description="Visible in sitemap.",
+            published=True,
+            active=True,
+            might_be_spam=False,
+        )
+        Project.objects.create(
+            title="Spam Project",
+            url="https://spam.example.com",
+            short_description="Hidden from sitemap.",
+            published=True,
+            active=True,
+            might_be_spam=True,
+        )
+
+        self.assertEqual(list(sitemaps["blog"].items()), [published_post])
+        self.assertEqual(list(sitemaps["projects"].items()), [visible_project])
+
+
+class SeoPageRenderTests(TestCase):
+    def setUp(self):
+        self.author = get_user_model().objects.create_user(
+            username="page-author",
+            email="page-author@example.com",
+            password="test-pass",
+        )
+
+    def test_blog_post_detail_renders_article_metadata(self):
+        post = Post.objects.create(
+            title='Django "SEO" Guide',
+            description="A practical guide to Django SEO.",
+            author=self.author,
+            slug="django-seo-guide",
+            content="Guide content",
+            status=Post.PUBLISHED,
+        )
+
+        response = self.client.get(post.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<meta property="og:type" content="article" />', html)
+        self.assertIn('<link rel="canonical" href="http://localhost:8000/blog/django-seo-guide" />', html)
+        self.assertIn('"headline": "Django \\"SEO\\" Guide"', html)
+
+    def test_project_detail_renders_twitter_image_not_duplicate_og_image(self):
+        project = Project.objects.create(
+            title="SEO Project",
+            url="https://project.example.com",
+            short_description="A project with clean metadata.",
+            published=True,
+            active=True,
+        )
+
+        response = self.client.get(project.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertEqual(html.count('property="og:image"'), 1)
+        self.assertIn('name="twitter:image"', html)
+        self.assertIn('<link rel="canonical" href="http://localhost:8000/projects/seo-project" />', html)
+
+    def test_job_and_developer_detail_render_structured_data(self):
+        job = Job.objects.create(
+            title="Django Engineer",
+            listing_url="https://jobs.example.com/django-engineer",
+            company_name="Example Co",
+            approved=True,
+        )
+        developer = Developer.objects.create(
+            user=self.author,
+            looking_for_a_job=True,
+            title="Senior Django Developer",
+            description="Builds production Django apps.",
+            capacity="FTC",
+            location="Madrid, Spain",
+        )
+
+        job_response = self.client.get(job.get_absolute_url())
+        developer_response = self.client.get(developer.get_absolute_url())
+
+        self.assertEqual(job_response.status_code, 200)
+        self.assertEqual(developer_response.status_code, 200)
+        self.assertIn('"@type": "JobPosting"', job_response.content.decode())
+        self.assertIn('"@type": "Person"', developer_response.content.decode())

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -13,6 +13,7 @@ from builtwithdjango.sitemaps import StaticViewSitemap, sitemaps
 from developers.models import Developer
 from jobs.models import Job
 from makers.models import Maker
+from podcast.models import Episode
 from projects.models import Project
 
 
@@ -218,7 +219,7 @@ class SeoPageRenderTests(TestCase):
             title="Senior Django Developer",
             description="Builds production Django apps.",
             capacity="FTC",
-            location="Madrid, Spain",
+            location="",
         )
 
         job_response = self.client.get(job.get_absolute_url())
@@ -230,4 +231,22 @@ class SeoPageRenderTests(TestCase):
         self.assertIn('<meta property="og:type" content="website" />', job_html)
         self.assertIn('"@type": "JobPosting"', job_html)
         self.assertNotIn('"address": ""', job_html)
-        self.assertIn('"@type": "Person"', developer_response.content.decode())
+        developer_html = developer_response.content.decode()
+        self.assertIn('"@type": "Person"', developer_html)
+        self.assertNotIn('"@type": "PostalAddress"', developer_html)
+        self.assertNotIn('"addressLocality": ""', developer_html)
+
+    def test_podcast_detail_uses_default_website_og_type(self):
+        episode = Episode.objects.create(
+            title="Podcast SEO",
+            slug="podcast-seo",
+            thumbnail="podcast/episode.png",
+            details="A podcast episode about Django SEO.",
+        )
+
+        response = self.client.get(episode.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<meta property="og:type" content="website" />', html)
+        self.assertIn('"@type": "PodcastEpisode"', html)

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from urllib.parse import urlencode
 
 import stripe
 from django.http import HttpResponseRedirect
@@ -91,16 +92,16 @@ class JobDetailView(DetailView):
         except ValueError:
             image_url = self.request.build_absolute_uri(static("vendors/images/logo.png"))
 
-        og_image_url = (
-            f"https://osig.app/g?"
-            f"site=x&"
-            f"title={title}&"
-            f"subtitle={description}&"
-            f"image_url={image_url}&"
-            f"font=helvetica&"
-            f"style=logo&"
-            f"key=dQrmHqDSY5"
-        )
+        og_image_params = {
+            "site": "x",
+            "title": title,
+            "subtitle": description,
+            "image_url": image_url,
+            "font": "helvetica",
+            "style": "logo",
+            "key": "dQrmHqDSY5",
+        }
+        og_image_url = f"https://osig.app/g?{urlencode(og_image_params)}"
         context["og_image"] = og_image_url
         context["company_logo_url"] = company_logo_url
 

--- a/pages/templatetags/seo.py
+++ b/pages/templatetags/seo.py
@@ -8,6 +8,11 @@ from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 
 register = template.Library()
+_json_ld_escapes = {
+    ord(">"): "\\u003E",
+    ord("<"): "\\u003C",
+    ord("&"): "\\u0026",
+}
 
 
 def _site_url():
@@ -46,7 +51,8 @@ def canonical_url(context, path=None):
 
 @register.filter
 def json_ld(value):
-    return mark_safe(json.dumps(value, cls=DjangoJSONEncoder, ensure_ascii=False))
+    value = json.dumps(value, cls=DjangoJSONEncoder, ensure_ascii=False).translate(_json_ld_escapes)
+    return mark_safe(value)
 
 
 @register.filter

--- a/pages/templatetags/seo.py
+++ b/pages/templatetags/seo.py
@@ -1,0 +1,76 @@
+import json
+from urllib.parse import urlencode, urljoin
+
+from django import template
+from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.html import strip_tags
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+def _site_url():
+    return getattr(settings, "SITE_URL", "").rstrip("/")
+
+
+@register.simple_tag(takes_context=True)
+def absolute_url(context, value="/"):
+    if not value:
+        value = "/"
+
+    value = str(value).strip()
+    if value.startswith(("http://", "https://")):
+        return value
+    if value.startswith("//"):
+        return f"https:{value}"
+
+    site_url = _site_url()
+    if site_url:
+        return urljoin(f"{site_url}/", value.lstrip("/"))
+
+    request = context.get("request")
+    if request:
+        return request.build_absolute_uri(value)
+
+    return value
+
+
+@register.simple_tag(takes_context=True)
+def canonical_url(context, path=None):
+    request = context.get("request")
+    if path is None and request:
+        path = request.path
+    return absolute_url(context, path or "/")
+
+
+@register.filter
+def json_ld(value):
+    return mark_safe(json.dumps(value, cls=DjangoJSONEncoder, ensure_ascii=False))
+
+
+@register.filter
+def seo_text(value, length=300):
+    try:
+        length = int(length)
+    except (TypeError, ValueError):
+        length = 300
+    text = strip_tags(str(value or "")).replace("\n", " ").strip()
+    return " ".join(text.split())[:length]
+
+
+@register.simple_tag
+def osig_image(title, subtitle="", eyebrow="", site="x", image_url="", style="base", font="markerfelt"):
+    params = {
+        "style": style,
+        "site": site,
+        "font": font,
+        "title": title,
+    }
+    if subtitle:
+        params["subtitle"] = subtitle
+    if eyebrow:
+        params["eyebrow"] = eyebrow
+    if image_url:
+        params["image_url"] = image_url
+    return f"https://osig.app/g?{urlencode(params)}"

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -71,6 +71,7 @@ class HomeViewTests(TestCase):
                 slug=f"guide-{index}",
                 content="Guide content",
                 type=Post.TUTORIAL,
+                status=Post.PUBLISHED,
             )
 
         request = self.factory.get("/")

--- a/pages/views.py
+++ b/pages/views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from urllib.parse import urlencode
 
 from allauth.account.models import EmailAddress
 from django.conf import settings
@@ -42,7 +43,7 @@ class HomeView(TemplateView):
         context["projects"] = Project.objects.filter(published=True, active=True).order_by("-sponsored", "-date_added")[
             :6
         ]
-        context["guides"] = Post.objects.filter(type="TUTORIAL")[:6]
+        context["guides"] = Post.objects.filter(type=Post.TUTORIAL, status=Post.PUBLISHED)[:6]
         context["podcast_episodes"] = Episode.objects.all()[:3]
         filter_date = timezone.now() - timedelta(days=60)
         context["jobs"] = Job.objects.filter(approved=True, created_datetime__gte=filter_date).order_by(
@@ -52,16 +53,16 @@ class HomeView(TemplateView):
         title = "Built with Django"
         description = "Learn to bring your project and business ideas to life with Django. Get inspired by others."
         logo_url = self.request.build_absolute_uri(static("vendors/images/logo.png"))
-        og_image_url = (
-            f"https://osig.app/g?"
-            f"site=x&"
-            f"title={title}&"
-            f"subtitle={description}&"
-            f"image_url={logo_url}&"
-            f"font=markerfelt&"
-            f"style=logo&"
-            f"key=dQrmHqDSY5"
-        )
+        og_image_params = {
+            "site": "x",
+            "title": title,
+            "subtitle": description,
+            "image_url": logo_url,
+            "font": "markerfelt",
+            "style": "logo",
+            "key": "dQrmHqDSY5",
+        }
+        og_image_url = f"https://osig.app/g?{urlencode(og_image_params)}"
         context["og_image"] = og_image_url
 
         return context

--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -3,7 +3,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-  <title>Built with Django - Confirm Email</title>
+  {% include "components/seo_meta.html" with title="Confirm Email | Built with Django" description="Confirm your Built with Django email address." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -2,9 +2,9 @@
 {% load socialaccount %}
 {% load widget_tweaks %}
 
-{% block title %}
-    Log In
-{% endblock title %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Log In | Built with Django" description="Log in to Built with Django." canonical_path="/users/login/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 
 {% block content %}
     <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
-{% block title %}Sign Out{% endblock title %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Sign Out | Built with Django" description="Sign out of Built with Django." canonical_path="/users/logout/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <div class="mx-auto my-4 prose md:my-10 lg:prose-lg">
         <h1 class="text-center">Please confirm Sign Out</h1>

--- a/templates/account/profile-update.html
+++ b/templates/account/profile-update.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load widget_tweaks %}
 {% block meta %}
-    <title>Built with Django | Update Profile</title>
+    {% include "components/seo_meta.html" with title="Update Profile | Built with Django" description="Update your Built with Django profile." canonical_path="/users/update/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
     <section class="py-8 sm:py-10 lg:py-12"

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -2,9 +2,9 @@
 {% load socialaccount %}
 {% load widget_tweaks %}
 
-{% block title %}
-    Sign Up
-{% endblock title %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Sign Up | Built with Django" description="Create a Built with Django account." canonical_path="/users/signup/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 
 {% block content %}
     <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">

--- a/templates/account/upgrade-account.html
+++ b/templates/account/upgrade-account.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block meta %}
-    <title>Built with Django | Account Plans</title>
+    {% include "components/seo_meta.html" with title="Account Plans | Built with Django" description="Manage your Built with Django account plan." canonical_path="/users/upgrade/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
     <section class="py-12 sm:py-16 lg:py-20" aria-labelledby="account-plans-title">

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,22 +8,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="apple-touch-icon" href="{% static 'vendors/favicon/logo.png' %}" />
     <link rel="icon" type="image/png" sizes="16x16 32x32 500x500" href="{% static 'vendors/favicon/logo.png' %}" />
-    <meta property="og:type" content="website" />
 
     {% block meta %}
-      <title>Built with Django</title>
-      <meta name="description" content="Collection of cool projects people built with Django" />
-      <link rel="canonical" href="https://{{ request.get_host }}" />
-      <meta property="og:title" content="Built with Django" />
-      <meta property="og:url" content="https://{{ request.get_host }}" />
-      <meta property="og:description" content="Collection of cool projects people built with Django" />
-      <meta property="og:image" content="{{ og_image }}" />
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:creator" content="@rasulkireev" />
-      <meta name="twitter:site" content="@builtwithdjango" />
-      <meta name="twitter:title" content="Built with Django" />
-      <meta name="twitter:description" content="Collection of cool projects people built with Django" />
-      <meta name="twitter:image" content="{{ og_image }}" />
+      {% include "components/seo_meta.html" with title="Built with Django" description="See what people are shipping with Django, learn from practical guides, find Django work, and discover useful community resources." canonical_path="/" image=og_image image_alt="Built with Django logo" %}
     {% endblock meta %}
 
     <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css" />
@@ -655,20 +642,39 @@
     {% include "components/bottom-right-corner-ad.html" %}
 
     {% block schema %}
+      {% canonical_url "/" as site_url %}
+      {% static "vendors/images/logo.png" as logo_path %}
+      {% absolute_url logo_path as logo_url %}
       <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "WebSite",
-        "name": "Projects Built with Django",
-        "description": "Collection of cool projects people built with Django",
-        "thumbnailUrl": "{{ og_image }}",
-        "url": "https://{{ request.get_host }}",
-        "author": {
-          "@type": "Person",
-          "givenName": "Rasul",
-          "familyName": "Kireev",
-          "url": "https://rasulkireev.com/"
-        }
+        "@graph": [
+          {
+            "@type": "WebSite",
+            "@id": "{{ site_url }}#website",
+            "name": "Built with Django",
+            "description": "See what people are shipping with Django, learn from practical guides, find Django work, and discover useful community resources.",
+            "url": "{{ site_url }}",
+            "publisher": {
+              "@id": "{{ site_url }}#organization"
+            }
+          },
+          {
+            "@type": "Organization",
+            "@id": "{{ site_url }}#organization",
+            "name": "Built with Django",
+            "url": "{{ site_url }}",
+            "logo": {
+              "@type": "ImageObject",
+              "url": "{{ logo_url }}"
+            },
+            "founder": {
+              "@type": "Person",
+              "name": "Rasul Kireev",
+              "url": "https://rasulkireev.com/"
+            }
+          }
+        ]
       }
       </script>
     {% endblock schema %}

--- a/templates/blog/all_articles.html
+++ b/templates/blog/all_articles.html
@@ -4,18 +4,7 @@
 {% load cloudinary %}
 
 {% block meta %}
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <title>Django Articles | Built with Django</title>
-    <meta name="description" content="Articles, updates, and Django community notes from Built with Django."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/blog/articles/" />
-    <meta property="og:title" content="Django Articles | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/blog/articles/" />
-    <meta property="og:description" content="Articles, updates, and Django community notes from Built with Django."/>
-    <meta name="twitter:title" content="Django Articles | Built with Django" />
-    <meta name="twitter:description" content="Articles, updates, and Django community notes from Built with Django."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Articles | Built with Django" description="Articles, updates, and Django community notes from Built with Django." canonical_path="/blog/articles/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -46,17 +35,16 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Built with Django | Articles",
     "about": "Articles",
     "description": "Articles, updates, and Django community notes from Built with Django.",
     "abstract": "Articles, updates, and Django community notes from Built with Django.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/blog/articles/",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/blog/articles/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/blog/all_posts.html
+++ b/templates/blog/all_posts.html
@@ -4,18 +4,7 @@
 {% load cloudinary %}
 
 {% block meta %}
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <title>Django Guides | Built with Django</title>
-    <meta name="description" content="Practical Django guides for people building real products."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/blog/" />
-    <meta property="og:title" content="Django Guides | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/blog/" />
-    <meta property="og:description" content="Practical Django guides for people building real products."/>
-    <meta name="twitter:title" content="Django Guides | Built with Django" />
-    <meta name="twitter:description" content="Practical Django guides for people building real products."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Guides | Built with Django" description="Practical Django guides for people building real products." canonical_path="/blog/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -46,17 +35,16 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Built with Django | Blog",
     "about": "Blog",
     "description": "Practical Django guides for people building real products.",
     "abstract": "Practical Django guides for people building real products.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/blog/",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/blog/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/blog/create-guide-comment.html
+++ b/templates/blog/create-guide-comment.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Add Guide Comment | Built with Django" description="Add a comment to a Built with Django guide." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <form action method="post">
         {% csrf_token %}

--- a/templates/blog/post_detail.html
+++ b/templates/blog/post_detail.html
@@ -4,19 +4,8 @@
 {% load url_utils %}
 
 {% block meta %}
-    <title>{{ object.title }}</title>
-    <link rel="canonical" href="https://{{ request.get_host }}/blog/{{ object.slug }}" />
-    <meta name="description" content="{{ object.description }}" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="{{ object.title }}" />
-    <meta name="twitter:description" content="{{ object.description }}" />
-    <meta name="twitter:image" content="https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.description }}&eyebrow=Article" />
-    <meta property="og:title" content="{{ object.title }}" />
-    <meta property="og:url" content="https://{{ request.get_host }}/blog/{{ object.slug }}" />
-    <meta property="og:description" content="{{ object.description }}" />
-    <meta property="og:image" content="https://osig.app/g?style=base&site=facebook&font=markerfelt&title={{ object.title }}&subtitle={{ object.description }}&eyebrow=Article" />
+    {% osig_image title=object.title subtitle=object.description eyebrow="Article" site="x" as article_image %}
+    {% include "components/seo_meta.html" with title=object.title description=object.description canonical_path=object.get_absolute_url image=article_image og_type="article" image_alt=object.title %}
 {% endblock meta %}
 
 {% block content %}
@@ -54,24 +43,35 @@
 {% endblock content %}
 
 {% block schema %}
+{% osig_image title=object.title subtitle=object.description eyebrow="Article" site="x" as article_image %}
 <script type="application/ld+json">
 {
-  "@context": "http://schema.org/",
+  "@context": "https://schema.org",
   "@type": "BlogPosting",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{% canonical_url object.get_absolute_url %}"
+  },
   "author": {
     "@type": "Person",
     "name": "Rasul Kireev",
-    "image": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}"
+    "url": "https://rasulkireev.com/"
   },
-  "headline": "{{ object.title }}",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Built with Django",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "{% absolute_url '/static/vendors/images/logo.png' %}"
+    }
+  },
+  "headline": {{ object.title|json_ld }},
+  "description": {{ object.description|json_ld }},
   "about": "Django",
-  "abstract": "{{ object.description }}",
-  "articleBody": "{% autoescape on %}{{ object.content|safe|replace_quotes }}{% endautoescape %}",
-  "image": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.description }}&eyebrow=Article",
-  "thumbnailUrl": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.description }}&eyebrow=Article",
-  "dateCreated": "{{ object.created }}",
-  "datePublished": "{{ object.created }}",
-  "dateModified": "{{ object.modified }}"
+  "image": {{ article_image|json_ld }},
+  "thumbnailUrl": {{ article_image|json_ld }},
+  "datePublished": "{{ object.created|date:'c' }}",
+  "dateModified": "{{ object.modified|date:'c' }}"
 }
 </script>
 {% endblock schema %}

--- a/templates/components/seo_meta.html
+++ b/templates/components/seo_meta.html
@@ -1,0 +1,23 @@
+{% load static %}
+{% static "vendors/images/logo.png" as default_share_image %}
+{% firstof image og_image default_share_image as share_image %}
+{% canonical_url canonical_path as canonical %}
+{% absolute_url share_image as share_image_url %}
+<title>{{ title|seo_text:70 }}</title>
+{% if description %}<meta name="description" content="{{ description|seo_text:300 }}" />{% endif %}
+{% if robots %}<meta name="robots" content="{{ robots }}" />{% endif %}
+<link rel="canonical" href="{{ canonical }}" />
+<meta property="og:site_name" content="Built with Django" />
+<meta property="og:type" content="{{ og_type|default:'website' }}" />
+<meta property="og:title" content="{{ title|seo_text:95 }}" />
+<meta property="og:url" content="{{ canonical }}" />
+{% if description %}<meta property="og:description" content="{{ description|seo_text:300 }}" />{% endif %}
+<meta property="og:image" content="{{ share_image_url }}" />
+{% if image_alt %}<meta property="og:image:alt" content="{{ image_alt|seo_text:120 }}" />{% endif %}
+<meta name="twitter:card" content="{{ twitter_card|default:'summary_large_image' }}" />
+<meta name="twitter:creator" content="{{ twitter_creator|default:'@rasulkireev' }}" />
+<meta name="twitter:site" content="{{ twitter_site|default:'@builtwithdjango' }}" />
+<meta name="twitter:title" content="{{ title|seo_text:95 }}" />
+{% if description %}<meta name="twitter:description" content="{{ description|seo_text:300 }}" />{% endif %}
+<meta name="twitter:image" content="{{ share_image_url }}" />
+{% if image_alt %}<meta name="twitter:image:alt" content="{{ image_alt|seo_text:120 }}" />{% endif %}

--- a/templates/developers/_developer_schema.json
+++ b/templates/developers/_developer_schema.json
@@ -1,0 +1,21 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{% canonical_url object.get_absolute_url %}"
+  },
+  "name": {{ object.title|json_ld }},
+  "description": {{ object.description|json_ld }},
+  "jobTitle": {{ object.get_role_display|json_ld }},
+  "url": "{% canonical_url object.get_absolute_url %}",
+  {% if developer_image %}
+  "image": {{ developer_image|json_ld }},
+  {% endif %}
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": {{ object.location|json_ld }}
+  }
+}
+</script>

--- a/templates/developers/_developer_schema.json
+++ b/templates/developers/_developer_schema.json
@@ -9,13 +9,11 @@
   "name": {{ object.title|json_ld }},
   "description": {{ object.description|json_ld }},
   "jobTitle": {{ object.get_role_display|json_ld }},
-  "url": "{% canonical_url object.get_absolute_url %}",
-  {% if developer_image %}
-  "image": {{ developer_image|json_ld }},
-  {% endif %}
+  "url": "{% canonical_url object.get_absolute_url %}"{% if developer_image %},
+  "image": {{ developer_image|json_ld }}{% endif %}{% if object.location %},
   "address": {
     "@type": "PostalAddress",
     "addressLocality": {{ object.location|json_ld }}
-  }
+  }{% endif %}
 }
 </script>

--- a/templates/developers/all_developers.html
+++ b/templates/developers/all_developers.html
@@ -3,19 +3,7 @@
 {% load markdown_extras %}
 
 {% block meta %}
-    <title>Django Developers | Built with Django</title>
-    <meta name="description" content="Discover Django developers available for work."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/developers/" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Developers | Built with Django" />
-    <meta name="twitter:description" content="Discover Django developers available for work."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django Developers | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/developers/" />
-    <meta property="og:description" content="Discover Django developers available for work."/>
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Developers | Built with Django" description="Discover Django developers available for work." canonical_path="/developers/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -70,17 +58,16 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Django Developers",
     "about": "Reverse Job Board",
     "description": "Discover Django developers available for work.",
     "abstract": "Discover Django developers available for work.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/developers/",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/developers/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/developers/create-profile.html
+++ b/templates/developers/create-profile.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Edit Developer Profile | Built with Django" description="Edit your Built with Django developer profile." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <form action method="post">
         {% csrf_token %}

--- a/templates/developers/developer_detail.html
+++ b/templates/developers/developer_detail.html
@@ -4,19 +4,21 @@
 {% load humanize %}
 
 {% block meta %}
-    <title>{{ object.title }}</title>
-    <meta name="description" content="{{ object.description }}"/>
-    <link rel="canonical" href="https://{{ request.get_host }}/developers/{{ object.id }}" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="{{ object.title }}" />
-    <meta name="twitter:description" content="{{ object.description }}"/>
-    <meta name="twitter:image" content="https://res.cloudinary.com/built-with-django/{{ object.user.profile_image }}" />
-    <meta property="og:title" content="{{ object.title }}" />
-    <meta property="og:url" content="https://{{ request.get_host }}/developers/{{ object.id }}" />
-    <meta property="og:description" content="{{ object.description }}"/>
-    <meta property="og:image" content="https://res.cloudinary.com/built-with-django/{{ object.user.profile_image }}" />
+    {% if object.user.profile_image %}
+      {% with developer_image="https://res.cloudinary.com/built-with-django/"|add:object.user.profile_image %}
+        {% if object.looking_for_a_job %}
+          {% include "components/seo_meta.html" with title=object.title description=object.description canonical_path=object.get_absolute_url image=developer_image twitter_card="summary" image_alt=object.title %}
+        {% else %}
+          {% include "components/seo_meta.html" with title=object.title description=object.description canonical_path=object.get_absolute_url image=developer_image twitter_card="summary" robots="noindex,follow" image_alt=object.title %}
+        {% endif %}
+      {% endwith %}
+    {% else %}
+      {% if object.looking_for_a_job %}
+        {% include "components/seo_meta.html" with title=object.title description=object.description canonical_path=object.get_absolute_url twitter_card="summary" image_alt="Built with Django logo" %}
+      {% else %}
+        {% include "components/seo_meta.html" with title=object.title description=object.description canonical_path=object.get_absolute_url twitter_card="summary" robots="noindex,follow" image_alt="Built with Django logo" %}
+      {% endif %}
+    {% endif %}
 {% endblock meta %}
 
 {% block content %}
@@ -125,14 +127,11 @@
 {% endblock content %}
 
 {% block schema %}
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "{{ object.title }}",
-    "description": "{{ object.description }}",
-    "thumbnailUrl": "https://res.cloudinary.com/built-with-django/{{ object.user.profile_image }}",
-    "url": "https://{{ request.get_host }}/developers/{{ object.id }}"
-  }
-  </script>
+  {% if object.user.profile_image %}
+    {% with developer_image="https://res.cloudinary.com/built-with-django/"|add:object.user.profile_image %}
+      {% include "developers/_developer_schema.json" with developer_image=developer_image %}
+    {% endwith %}
+  {% else %}
+    {% include "developers/_developer_schema.json" %}
+  {% endif %}
 {% endblock schema %}

--- a/templates/developers/pricing-details.html
+++ b/templates/developers/pricing-details.html
@@ -3,19 +3,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Django Developers - Pricing</title>
-    <meta name="description" content="Subscription Pricing Details for Django Developers"/>
-    <link rel="canonical" href="https://{{ request.get_host }}/developers/pricing" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Developers - Pricing" />
-    <meta name="twitter:description" content="Connect with hundreds of Django developers looking for their next job."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django Developers - Pricing" />
-    <meta property="og:url" content="https://{{ request.get_host }}/developers/pricing" />
-    <meta property="og:description" content="Connect with hundreds of Django developers looking for their next job."/>
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Developers - Pricing" description="Manage your Django developer profile subscription." canonical_path="/developers/pricing" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -116,17 +104,15 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "WebPage",
     "name": "Django Developers - Pricing",
     "about": "Reverse Job Board",
-    "description": "Connect with hundreds of Django developers looking for their next job.",
-    "abstract": "Connect with hundreds of Django developers looking for their next job.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/developers/pricing",
+    "description": "Manage your Django developer profile subscription.",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/developers/pricing' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/jobs/_job_posting_schema.json
+++ b/templates/jobs/_job_posting_schema.json
@@ -14,7 +14,7 @@
   "directApply": true,
   {% if object.remote %}
   "jobLocationType": "TELECOMMUTE",
-  {% else %}
+  {% elif object.location %}
   "jobLocation": {
     "@type": "Place",
     "address": {{ object.location|json_ld }}

--- a/templates/jobs/_job_posting_schema.json
+++ b/templates/jobs/_job_posting_schema.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://schema.org",
+  "@type": "JobPosting",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{% canonical_url object.get_absolute_url %}"
+  },
+  "title": {{ object.title|json_ld }},
+  "name": {{ object.title|json_ld }},
+  "description": {% if object.description %}{{ object.description|seo_text:5000|json_ld }}{% else %}{{ company_name|add:" is looking for a "|add:object.title|json_ld }}{% endif %},
+  "datePosted": "{{ object.created_datetime|date:'c' }}",
+  "employmentType": "FULL_TIME",
+  "url": {{ object.listing_url|json_ld }},
+  "directApply": true,
+  {% if object.remote %}
+  "jobLocationType": "TELECOMMUTE",
+  {% else %}
+  "jobLocation": {
+    "@type": "Place",
+    "address": {{ object.location|json_ld }}
+  },
+  {% endif %}
+  "hiringOrganization": {
+    "@type": "Organization",
+    "name": {{ company_name|json_ld }}{% if company_url %},
+    "sameAs": {{ company_url|json_ld }}{% endif %}{% if company_logo_url %},
+    "logo": "{% absolute_url company_logo_url %}"{% endif %}
+  }
+}

--- a/templates/jobs/all_all_jobs.html
+++ b/templates/jobs/all_all_jobs.html
@@ -3,19 +3,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Django Jobs</title>
-    <meta name="description" content="Django jobs for people who want to work with Django."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/jobs/" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Jobs" />
-    <meta name="twitter:description" content="Django jobs for people who want to work with Django."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django Jobs" />
-    <meta property="og:url" content="https://{{ request.get_host }}/jobs/" />
-    <meta property="og:description" content="Django jobs for people who want to work with Django."/>
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Jobs | Built with Django" description="Django jobs for people who want to work with Django." canonical_path="/jobs/all" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -23,7 +11,7 @@
     <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
       <div class="max-w-2xl mx-auto text-center">
         <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Django Jobs</h1>
-        <p class="mt-6 text-lg leading-8 prose text-gray-600">Advertize your jobs to people who want to work with Django.</p>
+        <p class="mt-6 text-lg leading-8 prose text-gray-600">Advertise your jobs to people who want to work with Django.</p>
       </div>
       <div class="flex flex-wrap items-center justify-between mt-8 sm:flex-nowrap">
           <div class="mx-auto">
@@ -67,17 +55,16 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Django Jobs",
     "about": "Job Board",
     "description": "Django jobs for people who want to work with Django.",
     "abstract": "Django jobs for people who want to work with Django.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/jobs/",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/jobs/all' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -3,19 +3,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Django Jobs | Built with Django</title>
-    <meta name="description" content="Django jobs for developers who want to work with Django." />
-    <link rel="canonical" href="https://{{ request.get_host }}/jobs/" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Jobs | Built with Django" />
-    <meta name="twitter:description" content="Django jobs for developers who want to work with Django." />
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django Jobs | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/jobs/" />
-    <meta property="og:description" content="Django jobs for developers who want to work with Django." />
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Jobs | Built with Django" description="Django jobs for developers who want to work with Django." canonical_path="/jobs/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -60,17 +48,16 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Django Jobs",
     "about": "Job Board",
     "description": "Django jobs for developers who want to work with Django.",
     "abstract": "Django jobs for developers who want to work with Django.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/jobs/",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/jobs/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -7,13 +7,13 @@
     {% if object.company %}
       {% with company_name=object.company.name %}
         {% with page_title=object.title|add:" @ "|add:company_name page_description=company_name|add:" is looking for a "|add:object.title %}
-          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image og_type="article" image_alt=page_title %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image image_alt=page_title %}
         {% endwith %}
       {% endwith %}
     {% else %}
       {% with company_name=object.company_name %}
         {% with page_title=object.title|add:" @ "|add:company_name page_description=company_name|add:" is looking for a "|add:object.title %}
-          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image og_type="article" image_alt=page_title %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image image_alt=page_title %}
         {% endwith %}
       {% endwith %}
     {% endif %}

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -4,21 +4,19 @@
 {% load humanize %}
 
 {% block meta %}
-    <title>{{ object.title }} @ {% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}</title>
-    <meta name="description" content="{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %} is looking for a {{ object.title }}" />
-    <link rel="canonical" href="https://{{ request.get_host }}/jobs/{{ object.pk }}/{{ object.slug }}" />
-
-    <meta property="og:url" content="https://{{ request.get_host }}/jobs/{{ object.pk }}/{{ object.slug }}" />
-    <meta property="og:title" content="{{ object.title }} @ {% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}" />
-    <meta property="og:description" content="{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %} is looking for a {{ object.title }}" />
-    <meta property="og:image" content="{{ og_image }}" />
-
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="{{ object.title }} @ {% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}" />
-    <meta name="twitter:description" content="{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %} is looking for a {{ object.title }}" />
-    <meta name="twitter:image" content="{{ og_image }}" />
+    {% if object.company %}
+      {% with company_name=object.company.name %}
+        {% with page_title=object.title|add:" @ "|add:company_name page_description=company_name|add:" is looking for a "|add:object.title %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image og_type="article" image_alt=page_title %}
+        {% endwith %}
+      {% endwith %}
+    {% else %}
+      {% with company_name=object.company_name %}
+        {% with page_title=object.title|add:" @ "|add:company_name page_description=company_name|add:" is looking for a "|add:object.title %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image og_type="article" image_alt=page_title %}
+        {% endwith %}
+      {% endwith %}
+    {% endif %}
 {% endblock meta %}
 
 {% block content %}
@@ -124,24 +122,14 @@
 
 {% block schema %}
     <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "JobPosting",
-  "name":"{{ object.title }}",
-  "title":"{{ object.title }}",
-  "jobLocation": {
-    "@type": "Place",
-    "address": "{% if object.remote %}Remote{% else %}{{ object.location }}{% endif %}"
-  },
-  "description": "{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %} is looking for a {{ object.title }}",
-  "datePosted": "{{ object.created_datetime }}",
-  "employmentType": "full-time",
-  "url": "{{ object.listing_url }}",
-  "directApply": true,
-  "hiringOrganization": {
-    "@type": "Organization",
-    "name": "{% if object.company %}{{ object.company.name }}{% else %}{{ object.company_name }}{% endif %}"
-  }
-}
+{% if object.company %}
+{% with company_name=object.company.name company_url=object.company.url %}
+{% include "jobs/_job_posting_schema.json" with company_name=company_name company_url=company_url %}
+{% endwith %}
+{% else %}
+{% with company_name=object.company_name company_url="" %}
+{% include "jobs/_job_posting_schema.json" with company_name=company_name company_url=company_url %}
+{% endwith %}
+{% endif %}
     </script>
 {% endblock schema %}

--- a/templates/jobs/post-job-thank-you.html
+++ b/templates/jobs/post-job-thank-you.html
@@ -1,18 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block meta %}
-    <title>Built with Django</title>
-    <meta name="description" content="Collection of cool projects people built with Django" />
-    <link rel="canonical" href="https://{{ request.get_host }}/jobs/thank-you" />
-    <meta property="og:title" content="Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/jobs/thank-you" />
-    <meta property="og:description" content="Collection of cool projects people built with Django" />
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Built with Django" />
-    <meta name="twitter:description" content="Collection of cool projects people built with Django" />
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Thanks for Posting a Django Job | Built with Django" description="Your Django job was submitted to Built with Django." canonical_path="/jobs/thank-you" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
     <div class="my-10 prose md:mx-auto lg:prose-xl">

--- a/templates/jobs/post-job.html
+++ b/templates/jobs/post-job.html
@@ -3,18 +3,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Post a Django Job | Built with Django</title>
-    <meta name="description" content="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." />
-    <link rel="canonical" href="https://{{ request.get_host }}/jobs/new" />
-    <meta property="og:title" content="Post a Django Job | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/jobs/new" />
-    <meta property="og:description" content="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." />
-    <meta property="og:image" content="{% static 'vendors/images/logo.png' %}" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Post a Django Job | Built with Django" />
-    <meta name="twitter:description" content="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." />
-    <meta name="twitter:image" content="{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Post a Django Job | Built with Django" description="Post a Django job for the Built with Django community. Sponsorship payment is optional after submitting, and your job still appears on the board." canonical_path="/jobs/new" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/makers/all_makers.html
+++ b/templates/makers/all_makers.html
@@ -1,18 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block meta %}
-    <title>Built with Django | Makers</title>
-    <meta name="description" content="Coolest Django makers!" />
-    <link rel="canonical" href="https://{{ request.get_host }}/projects/makers/" />
-    <meta property="og:title" content="Coolest Django Makers!" />
-    <meta property="og:url" content="https://{{ request.get_host }}/projects/makers/" />
-    <meta property="og:description" content="Coolest Django makers!" />
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Coolest Django Makers!" />
-    <meta name="twitter:description" content="Coolest Django makers!" />
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Makers | Built with Django" description="Meet the makers behind projects built with Django." canonical_path="/makers/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
     <div class="overflow-hidden my-4 bg-white rounded-lg shadow">
@@ -157,15 +146,14 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "Built with Django | Makers",
-    "description": "Coolest Django makers!",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}",
+    "@type": "CollectionPage",
+    "name": "Django Makers | Built with Django",
+    "description": "Meet the makers behind projects built with Django.",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/makers/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/makers/claim_account.html
+++ b/templates/makers/claim_account.html
@@ -1,4 +1,8 @@
 {% extends "base.html" %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Claim Maker Profile | Built with Django" description="Claim a Built with Django maker profile." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
+{% block content %}
 <form class="absolute top-0 right-0 p-2" method="post">
     {% csrf_token %}
     <input class="hidden" type="text" value="{{ user.email }}" />
@@ -7,3 +11,4 @@
         Claim
     </button>
 </form>
+{% endblock content %}

--- a/templates/makers/maker_detail.html
+++ b/templates/makers/maker_detail.html
@@ -3,23 +3,22 @@
 {% load markdown_extras %}
 
 {% block meta %}
-    <title>Built with Django | {{ object.first_name }} {{ object.last_name }}</title>
-    <meta name="description" content="{{ object.first_name }} {{ object.last_name }} builds with Django" />
-    <link rel="canonical" href="https://{{ request.get_host }}/makers/{{ object.slug }}" />
-    <meta property="og:title" content="{{ object.first_name }} {{ object.last_name }} builds with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/makers/{{ object.slug }}" />
-    <meta property="og:description" content="{{ object.first_name }} {{ object.last_name }} builds with Django" />
-    <meta property="og:image" content="{% get_media_prefix %}{{ object.maker_profile_image }}" />
-    {% if object.twitter_handle %}
-        <meta name="twitter:creator" content="@{{ object.twitter_handle }}" />
-        <meta name="twitter:site" content="@{{ object.twitter_handle }}" />
-    {% else %}
-        <meta name="twitter:creator" content="@rasulkireev" />
-        <meta name="twitter:site" content="@rasulkireev" />
-    {% endif %}
-    <meta name="twitter:title" content="{{ object.first_name }} {{ object.last_name }} builds with Django" />
-    <meta name="twitter:description" content="{{ object.first_name }} {{ object.last_name }} builds with Django" />
-    <meta name="twitter:image" content="{% get_media_prefix %}{{ object.maker_profile_image }}" />
+    {% with maker_name=object.first_name|add:" "|add:object.last_name %}
+      {% with page_title=maker_name|add:" | Built with Django" page_description=maker_name|add:" builds with Django." %}
+        {% if object.maker_profile_image %}
+          {% absolute_url object.maker_profile_image.url as maker_image %}
+          {% if object.twitter_handle %}
+            {% with maker_twitter="@"|add:object.twitter_handle %}
+              {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=maker_image twitter_creator=maker_twitter twitter_site="@builtwithdjango" twitter_card="summary" image_alt=maker_name %}
+            {% endwith %}
+          {% else %}
+            {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=maker_image twitter_card="summary" image_alt=maker_name %}
+          {% endif %}
+        {% else %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url twitter_card="summary" image_alt="Built with Django logo" %}
+        {% endif %}
+      {% endwith %}
+    {% endwith %}
 {% endblock meta %}
 
 {% block content %}
@@ -135,20 +134,21 @@
 {% endblock content %}
 
 {% block schema %}
+    {% with maker_name=object.first_name|add:" "|add:object.last_name %}
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
-    "name": "Built with Django | {{ object.first_name }} {{ object.last_name }}",
-    "description": "{{ object.first_name }} {{ object.last_name }} builds with Django",
-    "thumbnailUrl": "{% get_media_prefix %}{{ object.maker_profile_image }}",
-    "url": "https://{{ request.get_host }}/makers/{{ object.slug }}",
-    "author": {
-      "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
-      "url": "https://rasulkireev.com/"
-    }
+    "@type": "Person",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "{% canonical_url object.get_absolute_url %}"
+    },
+    "name": {{ maker_name|json_ld }},
+    "description": {{ maker_name|add:" builds with Django."|json_ld }},
+    "url": "{% canonical_url object.get_absolute_url %}"{% if object.maker_profile_image %},
+    "image": "{% absolute_url object.maker_profile_image.url %}"{% endif %}{% if object.personal_website %},
+    "sameAs": {{ object.personal_website|json_ld }}{% endif %}
   }
     </script>
+    {% endwith %}
 {% endblock schema %}

--- a/templates/makers/maker_detail_update.html
+++ b/templates/makers/maker_detail_update.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load static %}
 {% load markdown_extras %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Edit Maker Profile | Built with Django" description="Edit a Built with Django maker profile." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     {% if user == object.user %}
         <div class="max-w-5xl mx-auto my-10">

--- a/templates/newsletter/email-form.html
+++ b/templates/newsletter/email-form.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Built with Django Newsletter" description="Get new Django projects, guides, jobs, and podcast episodes by email." canonical_path="/newsletter/" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <div class="w-auto mx-auto mt-10 lg:w-1/3">
         <div class="p-8 mb-6 bg-white border-t-8 border-green-500 rounded-lg shadow-lg">

--- a/templates/newsletter/sucessfull-email-submit.html
+++ b/templates/newsletter/sucessfull-email-submit.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Newsletter Signup Complete | Built with Django" description="Thanks for signing up for the Built with Django newsletter." canonical_path="/newsletter/email-signup-thanks/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <div class="mx-auto mb-10 text-center">
         <h1 class="text-4xl">Thanks for signing up!</h1>

--- a/templates/pages/admin-panel.html
+++ b/templates/pages/admin-panel.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block meta %}
-    <title>Admin Panel - Built with Django</title>
+    {% include "components/seo_meta.html" with title="Admin Panel | Built with Django" description="Built with Django admin panel." canonical_path="/admin-panel/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/pages/advertize.html
+++ b/templates/pages/advertize.html
@@ -2,13 +2,13 @@
 {% load static %}
 
 {% block meta %}
-    <title>Advertize on Built with Django</title>
+    {% include "components/seo_meta.html" with title="Advertise on Built with Django" description="Sponsor Built with Django and reach developers, founders, and teams building with Django." canonical_path="/advertize" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
 
 <article class="mx-auto mt-10 prose lg:prose-xl">
-  <h1 class="text-center">Advertize on Built with Django</h1>
+  <h1 class="text-center">Advertise on Built with Django</h1>
 
   <p>Built with Django gets around 5k unique visitors a month, with around 10k pageviews per month. You can check out the stats <a href="https://plausible-v2.cr.lvtd.dev/builtwithdjango.com/" target="_blank">here</a>.</p>
 

--- a/templates/pages/confirm-email.html
+++ b/templates/pages/confirm-email.html
@@ -1,5 +1,8 @@
 {% extends "base.html" %}
 {% load static %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Confirm NFT Email | Built with Django" description="Confirm your Cistercian Date Club request email." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <div class="my-10">
         {% if messages %}

--- a/templates/pages/request-nft.html
+++ b/templates/pages/request-nft.html
@@ -1,18 +1,8 @@
 {% extends "base.html" %}
 {% load static %}
 {% block meta %}
-    <title>Cistercian Date Club Request</title>
-    <meta name="description" content="Request a free NFT for the Cistercian Dates Club" />
-    <link rel="canonical" href="https://{{ request.get_host }}/request-nft/" />
-    <meta property="og:title" content="Request a free NFT for the Cistercian Dates Club" />
-    <meta property="og:url" content="https://{{ request.get_host }}/request-nft/" />
-    <meta property="og:description" content="Request a free NFT for the Cistercian Dates Club" />
-    <meta property="og:image" content="{% static 'vendors/images/banner.png' %}" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Request a free NFT for the Cistercian Dates Club" />
-    <meta name="twitter:description" content="Request a free NFT for the Cistercian Dates Club" />
-    <meta name="twitter:image" content="{% static 'vendors/images/banner.png' %}" />
+    {% static "vendors/images/banner.png" as nft_banner %}
+    {% include "components/seo_meta.html" with title="Cistercian Date Club Request" description="Request a free NFT for the Cistercian Dates Club." canonical_path="/request-nft/" image=nft_banner robots="noindex,follow" image_alt="Cistercian Date Club banner" %}
 {% endblock meta %}
 {% block content %}
     <div class="my-6">

--- a/templates/pages/support.html
+++ b/templates/pages/support.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block meta %}
-    <title>Support Built with Django</title>
+    {% include "components/seo_meta.html" with title="Support Built with Django" description="Support Built with Django through tools and services used to run the site." canonical_path="/support/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/pages/terms-of-service.html
+++ b/templates/pages/terms-of-service.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block meta %}
-    <title>Built with Django - Terms of Service</title>
+    {% include "components/seo_meta.html" with title="Terms of Service | Built with Django" description="Terms and conditions for using Built with Django." canonical_path="/terms/" robots="noindex,follow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/pages/uses.html
+++ b/templates/pages/uses.html
@@ -2,23 +2,7 @@
 {% load webpack_loader static %}
 
 {% block meta %}
-    <title>Technologies We Use | Built with Django</title>
-    <meta name="description" content="Technologies and Tools Used by Built with Django" />
-    <meta name="keywords" content="Built with Django, Technology Stack, Web Development" />
-    <meta name="robots" content="index, follow" />
-    <link rel="canonical" href="https://{{ request.get_host }}/uses" />
-    <meta property="og:type" content="article" />
-    <meta property="og:title" content="Technologies We Use | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/uses" />
-    <meta property="og:description" content="Technologies and Tools Used by Built with Django" />
-    <meta property="og:locale" content="en_US" />
-    <meta property="og:image" content="https://osig.app/g?site=meta&style=logo&font=markerfelt&title=Built with Django&subtitle=Tech we use&image_url=https://osig.app/g?site=x&style=logo&font=markerfelt&title=Built with Django&subtitle=Tech we use!&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@rasulkireev" />
-    <meta name="twitter:title" content="Technologies We Use | Built with Django" />
-    <meta name="twitter:description" content="Technologies and Tools Used by Built with Django" />
-    <meta name="twitter:image" content="https://osig.app/g?site=x&style=logo&font=markerfelt&title=Built with Django&subtitle=Tech we use&image_url=https://osig.app/g?site=x&style=logo&font=markerfelt&title=Built with Django&subtitle=Tech we use!&image_url=https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Technologies We Use | Built with Django" description="Technologies and tools used to run Built with Django." canonical_path="/uses" og_type="article" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -31,7 +15,7 @@
         </p>
         <ul>
             <li><strong><a href="https://osig.app/" target="_blank">OSIG</a>:</strong> For pretty OG images.</li>
-            <li><strong><a href="https://statushen/com/" target="_blank">Statushen</a>:</strong> For a Status Page.</li>
+            <li><strong><a href="https://statushen.com/" target="_blank">Statushen</a>:</strong> For a Status Page.</li>
             <li><strong><a href="https://sentry.io/" target="_blank">Sentry</a>:</strong> For error tracking and performance monitoring, ensuring a smooth user experience.</li>
             <li><strong><a href="https://hetzner.cloud/?ref=Ju1ttKSG0Fn7" target="_blank">Hetzner</a>:</strong> Our cloud infrastructure provider, hosting our servers and services.</li>
             <li><strong><a href="https://buttondown.email/refer/rasulkireev" target="_blank">Buttondown</a>:</strong> for the newsletter.</li>

--- a/templates/podcast/all_episodes.html
+++ b/templates/podcast/all_episodes.html
@@ -2,21 +2,7 @@
 {% load static %}
 
 {% block meta %}
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <title>Built with Django | Podcast</title>
-    <meta name="description"
-          content="Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/podcast/" />
-    <meta property="og:title" content="Built with Django | Podcast" />
-    <meta property="og:url" content="https://{{ request.get_host }}/podcast/" />
-    <meta property="og:description"
-          content="Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community."/>
-    <meta name="twitter:title" content="Built with Django | Podcast" />
-    <meta name="twitter:description"
-          content="Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Built with Django Podcast" description="Practical stories and patterns from the Django community." canonical_path="/podcast/" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -61,18 +47,16 @@
     "name": "Built with Django Podcast",
     "description": "Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community.",
     "abstract": "Built with Django Podcast is a way to catch up with practical stories and patterns from the Django community.",
-    "image": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}/podcast/",
+    "image": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/podcast/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     },
     "actor": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     },
     "webFeed": "https://feeds.transistor.fm/the-built-with-django-podcast"

--- a/templates/podcast/episode_detail.html
+++ b/templates/podcast/episode_detail.html
@@ -3,19 +3,8 @@
 {% load markdown_extras %}
 
 {% block meta %}
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <title>{{ object.title }}</title>
-    <meta name="description" content="{{ object.details }}" />
-    <link rel="canonical" href="https://{{ request.get_host }}/podcast/{{ object.slug }}" />
-    <meta property="og:title" content="{{ object.title }}" />
-    <meta property="og:url" content="https://{{ request.get_host }}/podcast/{{ object.slug }}" />
-    <meta property="og:description" content="{{ object.details }}" />
-    <meta property="og:image" content="https://{{ request.get_host }}{{ object.thumbnail.url }}" />
-    <meta name="twitter:title" content="{{ object.title }}" />
-    <meta name="twitter:description" content="{{ object.details }}" />
-    <meta name="twitter:image" content="https://{{ request.get_host }}{{ object.thumbnail.url }}" />
+    {% absolute_url object.thumbnail.url as episode_image %}
+    {% include "components/seo_meta.html" with title=object.title description=object.details canonical_path=object.get_absolute_url image=episode_image og_type="article" image_alt=object.title %}
 {% endblock meta %}
 
 {% block content %}
@@ -64,28 +53,28 @@
 {% endblock content %}
 
 {% block schema %}
+    {% absolute_url object.thumbnail.url as episode_image %}
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "PodcastEpisode",
-  "name":"{{ object.title }}",
+  "name": {{ object.title|json_ld }},
   "episodeNumber": {{ object.pk }},
-  "thumbnailUrl": "https://{{ request.get_host }}{% get_media_prefix %}{{ object.thumbnail }}",
+  "thumbnailUrl": {{ episode_image|json_ld }},
   "author": {
     "@type": "Person",
-    "givenName": "Rasul",
-    "familyName": "Kireev",
+    "name": "Rasul Kireev",
     "url": "https://rasulkireev.com/"
   },
-  "url": "https://{{ request.get_host }}/podcast/{{ object.slug }}",
+  "url": "{% canonical_url object.get_absolute_url %}",
   "partOfSeries": {
     "@type": "PodcastSeries",
     "name": "Built with Django Podcast",
-    "url": "https://{{ request.get_host }}/podcast/"
+    "url": "{% canonical_url '/podcast/' %}"
   },
-  "description": "{{ object.details }}",
-  "abstract": "{{ object.details }}",
-  "datePublished": "{{ object.created_datetime }}"
+  "description": {{ object.details|json_ld }},
+  "abstract": {{ object.details|json_ld }},
+  "datePublished": "{{ object.created_datetime|date:'c' }}"
 }
     </script>
 {% endblock schema %}

--- a/templates/podcast/episode_detail.html
+++ b/templates/podcast/episode_detail.html
@@ -4,7 +4,7 @@
 
 {% block meta %}
     {% absolute_url object.thumbnail.url as episode_image %}
-    {% include "components/seo_meta.html" with title=object.title description=object.details canonical_path=object.get_absolute_url image=episode_image og_type="article" image_alt=object.title %}
+    {% include "components/seo_meta.html" with title=object.title description=object.details canonical_path=object.get_absolute_url image=episode_image image_alt=object.title %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/projects/all_inactive_projects.html
+++ b/templates/projects/all_inactive_projects.html
@@ -2,6 +2,10 @@
 {% load static %}
 {% load widget_tweaks %}
 
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Inactive Django Projects | Built with Django" description="Inactive Django projects in the Built with Django directory." robots="noindex,nofollow" %}
+{% endblock meta %}
+
 {% block content %}
     <div class="px-6 py-20 bg-white sm:py-24 lg:px-8">
       <div class="mx-auto max-w-2xl text-center">
@@ -68,15 +72,14 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Projects Built with Django",
     "description": "Collection of cool projects people built with Django",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/projects/all_projects.html
+++ b/templates/projects/all_projects.html
@@ -3,19 +3,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Django Projects | Built with Django</title>
-    <meta name="description" content="Discover real projects and apps built with Django." />
-    <link rel="canonical" href="https://{{ request.get_host }}/projects/" />
-    <meta property="og:title" content="Django Projects | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/projects/" />
-    <meta property="og:description" content="Discover real projects and apps built with Django." />
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django Projects | Built with Django" />
-    <meta name="twitter:description" content="Discover real projects and apps built with Django." />
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django Projects | Built with Django" description="Discover real projects and apps built with Django." canonical_path="/projects/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -133,15 +121,14 @@
     <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebSite",
+    "@type": "CollectionPage",
     "name": "Projects Built with Django",
     "description": "Discover real projects and apps built with Django.",
-    "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-    "url": "https://{{ request.get_host }}",
+    "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+    "url": "{% canonical_url '/projects/' %}",
     "author": {
       "@type": "Person",
-      "givenName": "Rasul",
-      "familyName": "Kireev",
+      "name": "Rasul Kireev",
       "url": "https://rasulkireev.com/"
     }
   }

--- a/templates/projects/project_detail.html
+++ b/templates/projects/project_detail.html
@@ -3,23 +3,16 @@
 {% load markdown_extras %}
 
 {% block meta %}
-    <meta name="twitter:card" content="summary_large_image" />
-    {% if object.maker.twitter_handle %}
-        <meta name="twitter:creator" content="@{{ object.maker.twitter_handle }}" />
-        <meta name="twitter:site" content="@{{ object.maker.twitter_handle }}" />
-    {% endif %}
-    <title>{{ object.title }} is Built with Django</title>
-    <meta name="description" content="{{ object.short_description }}" />
-    <link rel="canonical" href="https://{{ request.get_host }}/projects/{{ object.slug }}" />
-    <meta property="og:title" content="{{ object.title }}" />
-    <meta property="og:url" content="https://{{ request.get_host }}/projects/{{ object.slug }}" />
-    <meta property="og:description" content="{{ object.short_description }}" />
-    <meta property="og:image" content="https://osig.app/g?style=base&site=facebook&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="{{ object.title }}" />
-    <meta name="twitter:description" content="{{ object.description }}" />
-    <meta property="og:image" content="https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}" />
+    {% osig_image title=object.title subtitle=object.short_description eyebrow="Project" site="x" image_url=project_screenshot_url as project_share_image %}
+    {% with page_title=object.title|add:" is Built with Django" %}
+      {% if object.maker.twitter_handle %}
+        {% with maker_twitter="@"|add:object.maker.twitter_handle %}
+          {% include "components/seo_meta.html" with title=page_title description=object.short_description canonical_path=object.get_absolute_url image=project_share_image twitter_creator=maker_twitter twitter_site="@builtwithdjango" image_alt=object.title %}
+        {% endwith %}
+      {% else %}
+        {% include "components/seo_meta.html" with title=page_title description=object.short_description canonical_path=object.get_absolute_url image=project_share_image image_alt=object.title %}
+      {% endif %}
+    {% endwith %}
 {% endblock meta %}
 
 {% block content %}
@@ -187,21 +180,31 @@
 {% endblock content %}
 
 {% block schema %}
+    {% osig_image title=object.title subtitle=object.short_description eyebrow="Project" site="x" image_url=project_screenshot_url as project_share_image %}
     <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "CreativeWork",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{% canonical_url object.get_absolute_url %}"
+  },
+  {% if object.maker %}
   "author": {
     "@type": "Person",
-    "givenName": "{{ object.maker.first_name }}",
-    "familyName": "{{ object.maker.last_name }}",
-    "url": "{{ object.personal_website }}",
-    "image": "https://{{ request.get_host }}{% get_media_prefix %}{{ object.maker.maker_profile_image }}"
+    {% with maker_name=object.maker.first_name|add:" "|add:object.maker.last_name %}
+    "name": {{ maker_name|json_ld }}{% if object.maker.personal_website %},
+    "url": {{ object.maker.personal_website|json_ld }}{% endif %}{% if object.maker.maker_profile_image %},
+    "image": "{% absolute_url object.maker.maker_profile_image.url %}"{% endif %}
+    {% endwith %}
   },
-  "name":"{{ object.title }}",
-  "thumbnailUrl": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}",
-  "image": "https://osig.app/g?style=base&site=x&font=markerfelt&title={{ object.title }}&subtitle={{ object.short_description }}&eyebrow=Project&image_url={{ project_screenshot_url }}",
-  "abstract": "{{ object.short_description }}"
+  {% endif %}
+  "name": {{ object.title|json_ld }},
+  "description": {{ object.short_description|json_ld }},
+  "url": {{ object.url|json_ld }},
+  "thumbnailUrl": {{ project_share_image|json_ld }},
+  "image": {{ project_share_image|json_ld }},
+  "abstract": {{ object.short_description|json_ld }}
 }
     </script>
 {% endblock schema %}

--- a/templates/projects/project_detail_update.html
+++ b/templates/projects/project_detail_update.html
@@ -2,6 +2,9 @@
 {% load static %}
 {% load widget_tweaks %}
 {% load markdown_extras %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Edit Project | Built with Django" description="Edit a project in the Built with Django directory." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     {% if user == object.maker.user or user == object.logged_in_maker %}
         <div class="max-w-5xl mx-auto my-10">

--- a/templates/projects/submit-comment.html
+++ b/templates/projects/submit-comment.html
@@ -1,4 +1,7 @@
 {% extends "base.html" %}
+{% block meta %}
+    {% include "components/seo_meta.html" with title="Add Project Comment | Built with Django" description="Add a comment to a Built with Django project." robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
+{% endblock meta %}
 {% block content %}
     <form action method="post">
         {% csrf_token %}

--- a/templates/projects/submit-project.html
+++ b/templates/projects/submit-project.html
@@ -4,18 +4,7 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    <title>Submit a Django Project | Built with Django</title>
-    <meta name="description" content="Submit a project to the Built with Django directory." />
-    <link rel="canonical" href="https://{{ request.get_host }}/projects/new/" />
-    <meta property="og:title" content="Submit a Django Project | Built with Django" />
-    <meta property="og:url" content="https://{{ request.get_host }}/projects/new/" />
-    <meta property="og:description" content="Submit a project to the Built with Django directory." />
-    <meta property="og:image" content="{% static 'vendors/images/logo.png' %}" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Submit a Django Project | Built with Django" />
-    <meta name="twitter:description" content="Submit a project to the Built with Django directory." />
-    <meta name="twitter:image" content="{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Submit a Django Project | Built with Django" description="Submit a project to the Built with Django directory." canonical_path="/projects/new/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/tools/format_html.html
+++ b/templates/tools/format_html.html
@@ -2,19 +2,7 @@
 {% load static %}
 
 {% block meta %}
-    <title>Django HTML Tempalte Formatter</title>
-    <meta name="description" content="Make your Django templates pretty in seconds."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/tools/format-html/" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Django HTML Tempalte Formatter" />
-    <meta name="twitter:description" content="Make your Django templates pretty in seconds."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Django HTML Tempalte Formatter" />
-    <meta property="og:url" content="https://{{ request.get_host }}/tools/format-html/" />
-    <meta property="og:description" content="Make your Django templates pretty in seconds."/>
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Django HTML Template Formatter | Built with Django" description="Format Django templates in seconds." canonical_path="/tools/format-html/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -67,20 +55,19 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "Django HTML Tempalte Formatter",
-        "description": "Make your Django templates pretty in seconds.",
-        "abstract": "Make your Django templates pretty in seconds.",
-        "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-        "url": "https://{{ request.get_host }}/tools/format-html/",
+        "name": "Django HTML Template Formatter | Built with Django",
+        "description": "Format Django templates in seconds.",
+        "abstract": "Format Django templates in seconds.",
+        "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+        "url": "{% canonical_url '/tools/format-html/' %}",
         "author": {
             "@type": "Person",
-            "givenName": "Rasul",
-            "familyName": "Kireev",
+            "name": "Rasul Kireev",
             "url": "https://rasulkireev.com/"
         },
         "mainEntity": {
             "@type": "WebApplication",
-            "name": "Django Secret Key Generator",
+            "name": "Django HTML Template Formatter",
             "applicationCategory": "DeveloperApplication",
             "operatingSystem": "All"
         }

--- a/templates/tools/generate_django_secret.html
+++ b/templates/tools/generate_django_secret.html
@@ -3,19 +3,7 @@
 {% load markdown_extras %}
 
 {% block meta %}
-    <title>Generate Django Secret Key</title>
-    <meta name="description" content="Generate a secure Django secret key for your project."/>
-    <link rel="canonical" href="https://{{ request.get_host }}/tools/generate-secret-key/" />
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@rasulkireev" />
-    <meta name="twitter:site" content="@builtwithdjango" />
-    <meta name="twitter:title" content="Generate Django Secret Key" />
-    <meta name="twitter:description" content="Generate a secure Django secret key for your project."/>
-    <meta name="twitter:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
-    <meta property="og:title" content="Generate Django Secret Key" />
-    <meta property="og:url" content="https://{{ request.get_host }}/tools/generate-secret-key/" />
-    <meta property="og:description" content="Generate a secure Django secret key for your project."/>
-    <meta property="og:image" content="https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}" />
+    {% include "components/seo_meta.html" with title="Generate Django Secret Key | Built with Django" description="Generate a secure Django secret key for your project." canonical_path="/tools/django-secret/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -59,15 +47,14 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "Generate Django Secret Key",
+        "name": "Generate Django Secret Key | Built with Django",
         "description": "Generate a secure Django secret key for your project.",
         "abstract": "Generate a secure Django secret key for your project.",
-        "thumbnailUrl": "https://{{ request.get_host }}{% static 'vendors/images/logo.png' %}",
-        "url": "https://{{ request.get_host }}/tools/generate-secret-key/",
+        "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
+        "url": "{% canonical_url '/tools/django-secret/' %}",
         "author": {
             "@type": "Person",
-            "givenName": "Rasul",
-            "familyName": "Kireev",
+            "name": "Rasul Kireev",
             "url": "https://rasulkireev.com/"
         },
         "mainEntity": {


### PR DESCRIPTION
## Summary
- Add shared SEO template helpers for canonical URLs, absolute share images, Open Graph/Twitter metadata, and JSON-LD escaping.
- Update public and private templates with consistent titles, descriptions, canonical URLs, share images, robots tags, and schema.org data.
- Tighten sitemap/indexing behavior so published posts, active non-spam projects, makers, developers, and public index pages are represented correctly.

## Validation
- `docker compose run --rm backend python manage.py check --settings=builtwithdjango.test_settings`
- Compiled all templates through Django's template loader.
- `docker compose run --rm backend pytest --tb=short`