### PR TITLE
[Frontend] Remove Project Card Screenshot Gap

### DIFF
--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -489,17 +489,18 @@
 
   .bw-project-card__media {
     display: block;
-    aspect-ratio: 16 / 10;
+    aspect-ratio: 1680 / 876;
     overflow: hidden;
     border-bottom: 1px solid var(--bw-border);
     background: var(--bw-surface-muted);
   }
 
   .bw-project-card__media img {
+    display: block;
     width: 100%;
     height: 100%;
     background: var(--bw-surface-muted);
-    object-fit: contain;
+    object-fit: cover;
     object-position: center top;
     transition: transform 240ms var(--bw-ease);
   }


### PR DESCRIPTION
## Summary
- Match project card media to the generated screenshot aspect ratio.
- Render project screenshots as block-level cover images so the muted media background no longer appears as a gap before the card text.

## Root cause
Project screenshots are generated at 1680x876, but the card media frame used a wider 16:10 ratio with contained, top-aligned images. That left unused muted background at the bottom of the media area on project cards.

## Validation
- npm run build
- Playwright layout check: card body starts at the media boundary with a measured 0px gap.
