### PR TITLE
[SEO] Tighten Indexation Controls

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -21,6 +21,7 @@ class PostListView(ListView):
 class ArticleListView(ListView):
     model = Post
     template_name = "blog/all_articles.html"
+    # Articles is the catch-all editorial page for non-tutorial post types like interviews and updates.
     queryset = Post.objects.filter(status=Post.PUBLISHED).exclude(type=Post.TUTORIAL).order_by("-created")
 
     def get_context_data(self, **kwargs):

--- a/blog/views.py
+++ b/blog/views.py
@@ -21,7 +21,7 @@ class PostListView(ListView):
 class ArticleListView(ListView):
     model = Post
     template_name = "blog/all_articles.html"
-    queryset = Post.objects.filter(status="PB").order_by("-created")
+    queryset = Post.objects.filter(status=Post.PUBLISHED).exclude(type=Post.TUTORIAL).order_by("-created")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/blog/views.py
+++ b/blog/views.py
@@ -21,8 +21,7 @@ class PostListView(ListView):
 class ArticleListView(ListView):
     model = Post
     template_name = "blog/all_articles.html"
-    # Articles is the catch-all editorial page for non-tutorial post types like interviews and updates.
-    queryset = Post.objects.filter(status=Post.PUBLISHED).exclude(type=Post.TUTORIAL).order_by("-created")
+    queryset = Post.objects.filter(status=Post.PUBLISHED, type=Post.ARTICLE).order_by("-created")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/builtwithdjango/sitemaps.py
+++ b/builtwithdjango/sitemaps.py
@@ -53,6 +53,17 @@ class StaticViewSitemap(sitemaps.Sitemap):
         return reverse(item)
 
 
+class CurrentJobSitemap(sitemaps.Sitemap):
+    priority = 0.8
+    protocol = "https"
+
+    def items(self):
+        return Job.objects.filter(approved=True, created_datetime__gte=Job.current_cutoff())
+
+    def lastmod(self, obj):
+        return obj.created_datetime
+
+
 sitemaps = {
     "static": StaticViewSitemap,
     "blog": GenericSitemap(
@@ -68,14 +79,7 @@ sitemaps = {
         priority=0.85,
         protocol="https",
     ),
-    "jobs": GenericSitemap(
-        {
-            "queryset": Job.objects.filter(approved=True),
-            "date_field": "created_datetime",
-        },
-        priority=0.8,
-        protocol="https",
-    ),
+    "jobs": CurrentJobSitemap,
     "podcast": GenericSitemap(
         {"queryset": Episode.objects.all(), "date_field": "created_datetime"}, priority=0.8, protocol="https"
     ),

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -375,12 +375,22 @@ class SeoPageRenderTests(TestCase):
             status=Post.PUBLISHED,
             type=Post.ARTICLE,
         )
+        update = Post.objects.create(
+            title="Update Listing Result",
+            description="A non-tutorial update that belongs on the articles page.",
+            author=self.author,
+            slug="update-listing-result",
+            content="Update content",
+            status=Post.PUBLISHED,
+            type=Post.UPDATE,
+        )
 
         response = self.client.get("/blog/articles/")
 
         self.assertEqual(response.status_code, 200)
         html = response.content.decode()
         self.assertIn(article.title, html)
+        self.assertIn(update.title, html)
         self.assertNotIn(tutorial.title, html)
 
     def test_podcast_detail_uses_default_website_og_type(self):

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -1,11 +1,13 @@
 import json
 import tempfile
+from datetime import timedelta
 from pathlib import Path
 
 from django.contrib.auth import get_user_model
 from django.template import Context, Template
 from django.template.loader import render_to_string
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
+from django.utils import timezone
 from webpack_boilerplate import utils as webpack_utils
 
 from blog.models import Post
@@ -59,6 +61,18 @@ class SeoTemplateTagTests(SimpleTestCase):
         self.assertNotIn("</script>", html)
         self.assertIn("\\u003C/script\\u003E", html)
         self.assertIn("\\u0026", html)
+
+    @override_settings(SITE_URL="https://builtwithdjango.com")
+    def test_robots_txt_declares_crawl_rules_and_sitemap(self):
+        response = self.client.get("/robots.txt")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/plain")
+        robots_txt = response.content.decode()
+        self.assertIn("User-agent: *", robots_txt)
+        self.assertIn("Allow: /", robots_txt)
+        self.assertIn("Disallow: /users/", robots_txt)
+        self.assertIn("Sitemap: https://builtwithdjango.com/sitemap.xml", robots_txt)
 
 
 class SeoSitemapTests(TestCase):
@@ -124,9 +138,30 @@ class SeoSitemapTests(TestCase):
             might_be_spam=False,
             maker=inactive_maker,
         )
+        current_job = Job.objects.create(
+            title="Current Django Engineer",
+            listing_url="https://jobs.example.com/current-django-engineer",
+            company_name="Current Co",
+            approved=True,
+            created_datetime=timezone.now() - timedelta(days=1),
+        )
+        Job.objects.create(
+            title="Expired Django Engineer",
+            listing_url="https://jobs.example.com/expired-django-engineer",
+            company_name="Expired Co",
+            approved=True,
+            created_datetime=timezone.now() - timedelta(days=61),
+        )
+        Job.objects.create(
+            title="Unapproved Django Engineer",
+            listing_url="https://jobs.example.com/unapproved-django-engineer",
+            company_name="Unapproved Co",
+            approved=False,
+        )
 
         self.assertEqual(list(sitemaps["blog"].items()), [published_post])
         self.assertEqual(list(sitemaps["projects"].items()), [visible_project])
+        self.assertEqual(list(sitemaps["jobs"]().items()), [current_job])
         self.assertEqual(list(sitemaps["makers"].items()), [visible_maker])
 
 
@@ -206,6 +241,46 @@ class SeoPageRenderTests(TestCase):
         self.assertIn('name="twitter:image"', html)
         self.assertIn('<link rel="canonical" href="http://localhost:8000/projects/seo-project" />', html)
 
+    def test_project_detail_excludes_non_public_projects(self):
+        project = Project.objects.create(
+            title="Hidden SEO Project",
+            url="https://hidden-project.example.com",
+            short_description="This project should not be publicly indexable.",
+            published=False,
+            active=True,
+            might_be_spam=False,
+        )
+
+        response = self.client.get(project.get_absolute_url())
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_project_page_two_self_canonicalizes(self):
+        for index in range(13):
+            Project.objects.create(
+                title=f"Paginated Project {index}",
+                url=f"https://paginated-project-{index}.example.com",
+                short_description="A project used to exercise pagination metadata.",
+                published=True,
+                active=True,
+                might_be_spam=False,
+            )
+
+        response = self.client.get("/projects/?page=2")
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<link rel="canonical" href="http://localhost:8000/projects/?page=2" />', html)
+        self.assertNotIn('<meta name="robots"', html)
+
+    def test_project_filters_are_noindexed(self):
+        response = self.client.get("/projects/?order_by=like")
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<link rel="canonical" href="http://localhost:8000/projects/" />', html)
+        self.assertIn('<meta name="robots" content="noindex,follow" />', html)
+
     def test_job_and_developer_detail_render_structured_data(self):
         job = Job.objects.create(
             title="Django Engineer",
@@ -230,11 +305,67 @@ class SeoPageRenderTests(TestCase):
         job_html = job_response.content.decode()
         self.assertIn('<meta property="og:type" content="website" />', job_html)
         self.assertIn('"@type": "JobPosting"', job_html)
+        self.assertIn('"validThrough":', job_html)
         self.assertNotIn('"address": ""', job_html)
         developer_html = developer_response.content.decode()
         self.assertIn('"@type": "Person"', developer_html)
         self.assertNotIn('"@type": "PostalAddress"', developer_html)
         self.assertNotIn('"addressLocality": ""', developer_html)
+
+    def test_job_detail_excludes_unapproved_jobs(self):
+        job = Job.objects.create(
+            title="Unapproved Django Engineer",
+            listing_url="https://jobs.example.com/unapproved-django-engineer",
+            company_name="Example Co",
+            approved=False,
+        )
+
+        response = self.client.get(job.get_absolute_url())
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_expired_job_detail_is_noindexed_but_keeps_expiration_schema(self):
+        job = Job.objects.create(
+            title="Expired Django Engineer",
+            listing_url="https://jobs.example.com/expired-django-engineer",
+            company_name="Example Co",
+            approved=True,
+            created_datetime=timezone.now() - timedelta(days=61),
+        )
+
+        response = self.client.get(job.get_absolute_url())
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<meta name="robots" content="noindex,follow" />', html)
+        self.assertIn('"validThrough":', html)
+
+    def test_article_listing_excludes_tutorials(self):
+        tutorial = Post.objects.create(
+            title="Tutorial Listing Overlap",
+            description="A tutorial that should stay on the guides page.",
+            author=self.author,
+            slug="tutorial-listing-overlap",
+            content="Tutorial content",
+            status=Post.PUBLISHED,
+            type=Post.TUTORIAL,
+        )
+        article = Post.objects.create(
+            title="Article Listing Result",
+            description="An article that belongs on the articles page.",
+            author=self.author,
+            slug="article-listing-result",
+            content="Article content",
+            status=Post.PUBLISHED,
+            type=Post.ARTICLE,
+        )
+
+        response = self.client.get("/blog/articles/")
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn(article.title, html)
+        self.assertNotIn(tutorial.title, html)
 
     def test_podcast_detail_uses_default_website_og_type(self):
         episode = Episode.objects.create(

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -324,6 +324,22 @@ class SeoPageRenderTests(TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    def test_all_jobs_archive_is_noindexed(self):
+        Job.objects.create(
+            title="Archived Django Engineer",
+            listing_url="https://jobs.example.com/archived-django-engineer",
+            company_name="Example Co",
+            approved=True,
+            created_datetime=timezone.now() - timedelta(days=61),
+        )
+
+        response = self.client.get("/jobs/all")
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<link rel="canonical" href="http://localhost:8000/jobs/all" />', html)
+        self.assertIn('<meta name="robots" content="noindex,follow" />', html)
+
     def test_expired_job_detail_is_noindexed_but_keeps_expiration_schema(self):
         job = Job.objects.create(
             title="Expired Django Engineer",

--- a/builtwithdjango/tests/test_seo.py
+++ b/builtwithdjango/tests/test_seo.py
@@ -340,6 +340,24 @@ class SeoPageRenderTests(TestCase):
         self.assertIn('<link rel="canonical" href="http://localhost:8000/jobs/all" />', html)
         self.assertIn('<meta name="robots" content="noindex,follow" />', html)
 
+    def test_all_jobs_archive_paginates_and_self_canonicalizes_pages(self):
+        for index in range(31):
+            Job.objects.create(
+                title=f"Archived Django Engineer {index}",
+                listing_url=f"https://jobs.example.com/archived-django-engineer-{index}",
+                company_name="Example Co",
+                approved=True,
+                created_datetime=timezone.now() - timedelta(days=61),
+            )
+
+        response = self.client.get("/jobs/all?page=2")
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn('<link rel="canonical" href="http://localhost:8000/jobs/all?page=2" />', html)
+        self.assertIn("Page 2 of 2", html)
+        self.assertIn('<meta name="robots" content="noindex,follow" />', html)
+
     def test_expired_job_detail_is_noindexed_but_keeps_expiration_schema(self):
         job = Job.objects.create(
             title="Expired Django Engineer",
@@ -377,7 +395,7 @@ class SeoPageRenderTests(TestCase):
         )
         update = Post.objects.create(
             title="Update Listing Result",
-            description="A non-tutorial update that belongs on the articles page.",
+            description="A non-article update that should stay out of the articles page.",
             author=self.author,
             slug="update-listing-result",
             content="Update content",
@@ -390,7 +408,7 @@ class SeoPageRenderTests(TestCase):
         self.assertEqual(response.status_code, 200)
         html = response.content.decode()
         self.assertIn(article.title, html)
-        self.assertIn(update.title, html)
+        self.assertNotIn(update.title, html)
         self.assertNotIn(tutorial.title, html)
 
     def test_podcast_detail_uses_default_website_og_type(self):

--- a/builtwithdjango/urls.py
+++ b/builtwithdjango/urls.py
@@ -24,6 +24,7 @@ from django.views.generic import TemplateView
 from users.webhooks import stripe_webhook
 
 from .sitemaps import sitemaps
+from .views import robots_txt
 
 urlpatterns = (
     [
@@ -49,7 +50,7 @@ urlpatterns = (
             {"sitemaps": sitemaps},
             name="django.contrib.sitemaps.views.sitemap",
         ),
-        path("robots.txt", include("robots.urls")),
+        path("robots.txt", robots_txt, name="robots_txt"),
     ]
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/builtwithdjango/views.py
+++ b/builtwithdjango/views.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.http import HttpResponse
+
+
+def robots_txt(request):
+    site_url = getattr(settings, "SITE_URL", "").rstrip("/")
+    if not site_url:
+        site_url = request.build_absolute_uri("/").rstrip("/")
+
+    lines = [
+        "User-agent: *",
+        "Allow: /",
+        "Disallow: /admin-panel/",
+        "Disallow: /api/",
+        "Disallow: /stripe/",
+        "Disallow: /users/",
+        f"Sitemap: {site_url}/sitemap.xml",
+    ]
+    return HttpResponse("\n".join(lines) + "\n", content_type="text/plain")

--- a/builtwithdjango/views.py
+++ b/builtwithdjango/views.py
@@ -1,7 +1,9 @@
 from django.conf import settings
 from django.http import HttpResponse
+from django.views.decorators.cache import cache_control
 
 
+@cache_control(max_age=86400)
 def robots_txt(request):
     site_url = getattr(settings, "SITE_URL", "").rstrip("/")
     if not site_url:

--- a/builtwithdjango/views.py
+++ b/builtwithdjango/views.py
@@ -14,6 +14,7 @@ def robots_txt(request):
         "Disallow: /api/",
         "Disallow: /stripe/",
         "Disallow: /users/",
+        "",
         f"Sitemap: {site_url}/sitemap.xml",
     ]
     return HttpResponse("\n".join(lines) + "\n", content_type="text/plain")

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -1,9 +1,13 @@
+from datetime import timedelta
+
 from autoslug import AutoSlugField
 from cloudinary.models import CloudinaryField
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
+
+JOB_LISTING_ACTIVE_DAYS = 60
 
 
 class Job(models.Model):
@@ -56,6 +60,18 @@ class Job(models.Model):
 
     def get_absolute_url(self):
         return reverse("job_details", kwargs={"pk": self.id, "slug": self.slug})
+
+    @classmethod
+    def current_cutoff(cls):
+        return timezone.now() - timedelta(days=JOB_LISTING_ACTIVE_DAYS)
+
+    @property
+    def expires_at(self):
+        return self.created_datetime + timedelta(days=JOB_LISTING_ACTIVE_DAYS)
+
+    @property
+    def is_active_listing(self):
+        return self.approved and self.created_datetime >= self.current_cutoff()
 
     def save(self, *args, **kwargs):
         """On save, update timestamps"""

--- a/jobs/tests.py
+++ b/jobs/tests.py
@@ -58,7 +58,7 @@ class JobListViewTests(TestCase):
         view = JobListView()
         view.setup(request)
 
-        with patch("jobs.views.timezone.now", return_value=now):
+        with patch("jobs.models.timezone.now", return_value=now):
             jobs = list(view.get_queryset())
 
         self.assertEqual(jobs, [recent_job])

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -19,6 +19,7 @@ from .tasks import notify_of_new_job
 class AllJobListView(ListView):
     model = Job
     template_name = "jobs/all_jobs.html"
+    paginate_by = 30
 
     def get_queryset(self):
         return Job.objects.filter(approved=True).order_by("-paid", "-created_datetime")
@@ -27,6 +28,8 @@ class AllJobListView(ListView):
         context = super().get_context_data(**kwargs)
         context["newsletter_form"] = NewsletterSignupForm
         context["canonical_path"] = reverse("all_jobs")
+        if context.get("page_obj") and context["page_obj"].number > 1:
+            context["canonical_path"] = f"{reverse('all_jobs')}?page={context['page_obj'].number}"
         context["robots"] = "noindex,follow"
 
         return context

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -26,7 +26,7 @@ class AllJobListView(ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["newsletter_form"] = NewsletterSignupForm
-        context["canonical_path"] = "/jobs/all"
+        context["canonical_path"] = reverse("all_jobs")
         context["robots"] = "noindex,follow"
 
         return context
@@ -84,7 +84,8 @@ class JobDetailView(DetailView):
         context["newsletter_form"] = NewsletterSignupForm
 
         job = self.object
-        context["job_robots"] = "" if job.is_active_listing else "noindex,follow"
+        if not job.is_active_listing:
+            context["job_robots"] = "noindex,follow"
         title = f"{job.company.name if job.company else job.company_name}"
         description = job.title
 

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -1,11 +1,9 @@
-from datetime import timedelta
 from urllib.parse import urlencode
 
 import stripe
 from django.http import HttpResponseRedirect
 from django.templatetags.static import static
 from django.urls import reverse, reverse_lazy
-from django.utils import timezone
 from django.views.generic import CreateView, DetailView, ListView, TemplateView
 from django_q.tasks import async_task
 
@@ -22,9 +20,14 @@ class AllJobListView(ListView):
     model = Job
     template_name = "jobs/all_jobs.html"
 
+    def get_queryset(self):
+        return Job.objects.filter(approved=True).order_by("-paid", "-created_datetime")
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["newsletter_form"] = NewsletterSignupForm
+        context["canonical_path"] = "/jobs/all"
+        context["robots"] = "noindex,follow"
 
         return context
 
@@ -34,8 +37,7 @@ class JobListView(ListView):
     template_name = "jobs/all_jobs.html"
 
     def get_queryset(self):
-        filter_date = timezone.now() - timedelta(days=60)
-        return Job.objects.filter(approved=True, created_datetime__gte=filter_date).order_by(
+        return Job.objects.filter(approved=True, created_datetime__gte=Job.current_cutoff()).order_by(
             "-paid", "-created_datetime"
         )[:30]
 
@@ -49,6 +51,12 @@ class JobListView(ListView):
 class JobDetailView(DetailView):
     model = Job
     template_name = "jobs/job_detail.html"
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.request.user.is_staff:
+            return queryset
+        return queryset.filter(approved=True)
 
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)
@@ -76,6 +84,7 @@ class JobDetailView(DetailView):
         context["newsletter_form"] = NewsletterSignupForm
 
         job = self.object
+        context["job_robots"] = "" if job.is_active_listing else "noindex,follow"
         title = f"{job.company.name if job.company else job.company_name}"
         description = job.title
 

--- a/projects/views.py
+++ b/projects/views.py
@@ -48,6 +48,14 @@ class ProjectListView(FilterView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["newsletter_form"] = NewsletterSignupForm
+        context["canonical_path"] = reverse("projects")
+
+        query_params = self.request.GET.copy()
+        query_params.pop("page", None)
+        if query_params:
+            context["robots"] = "noindex,follow"
+        elif context.get("page_obj") and context["page_obj"].number > 1:
+            context["canonical_path"] = f"{reverse('projects')}?page={context['page_obj'].number}"
 
         return context
 
@@ -64,6 +72,20 @@ class InactiveProjectListView(LoginRequiredMixin, UserPassesTestMixin, ListView)
 class ProjectDetailView(DetailView):
     model = Project
     template_name = "projects/project_detail.html"
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.request.user.is_staff:
+            return queryset
+
+        public_queryset = queryset.filter(published=True, active=True, might_be_spam=False)
+        if self.request.user.is_authenticated:
+            return queryset.filter(
+                Q(published=True, active=True, might_be_spam=False)
+                | Q(logged_in_maker=self.request.user)
+                | Q(maker__user=self.request.user)
+            ).distinct()
+        return public_queryset
 
     def get(self, request, *args, **kwargs):
         response = super().get(request, *args, **kwargs)

--- a/templates/blog/all_articles.html
+++ b/templates/blog/all_articles.html
@@ -4,7 +4,7 @@
 {% load cloudinary %}
 
 {% block meta %}
-    {% include "components/seo_meta.html" with title="Django Articles | Built with Django" description="Articles, updates, and Django community notes from Built with Django." canonical_path="/blog/articles/" twitter_card="summary" image_alt="Built with Django logo" %}
+    {% include "components/seo_meta.html" with title="Django Articles | Built with Django" description="Articles and Django community notes from Built with Django." canonical_path="/blog/articles/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}
@@ -12,7 +12,7 @@
   <div class="bw-container">
     <p class="bw-kicker">Articles</p>
     <h1 class="bw-heading-lg mt-3">Django notes from the community</h1>
-    <p class="bw-lede mt-5">Articles, updates, and collected context for people following the Django ecosystem.</p>
+    <p class="bw-lede mt-5">Articles and collected context for people following the Django ecosystem.</p>
   </div>
 </section>
 
@@ -38,8 +38,8 @@
     "@type": "CollectionPage",
     "name": "Built with Django | Articles",
     "about": "Articles",
-    "description": "Articles, updates, and Django community notes from Built with Django.",
-    "abstract": "Articles, updates, and Django community notes from Built with Django.",
+    "description": "Articles and Django community notes from Built with Django.",
+    "abstract": "Articles and Django community notes from Built with Django.",
     "thumbnailUrl": "{% absolute_url '/static/vendors/images/logo.png' %}",
     "url": "{% canonical_url '/blog/articles/' %}",
     "author": {

--- a/templates/jobs/_job_posting_schema.json
+++ b/templates/jobs/_job_posting_schema.json
@@ -9,6 +9,7 @@
   "name": {{ object.title|json_ld }},
   "description": {% if object.description %}{{ object.description|seo_text:5000|json_ld }}{% else %}{{ company_name|add:" is looking for a "|add:object.title|json_ld }}{% endif %},
   "datePosted": "{{ object.created_datetime|date:'c' }}",
+  "validThrough": "{{ object.expires_at|date:'c' }}",
   "employmentType": "FULL_TIME",
   "url": {{ object.listing_url|json_ld }},
   "directApply": true,

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -3,7 +3,8 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    {% include "components/seo_meta.html" with title="Django Jobs | Built with Django" description="Django jobs for developers who want to work with Django." canonical_path="/jobs/" twitter_card="summary" image_alt="Built with Django logo" %}
+    {% firstof canonical_path "/jobs/" as jobs_canonical_path %}
+    {% include "components/seo_meta.html" with title="Django Jobs | Built with Django" description="Django jobs for developers who want to work with Django." canonical_path=jobs_canonical_path robots=robots twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -38,6 +38,26 @@
         <a href="{% url 'post_job' %}" class="bw-button bw-button-accent mt-6">Post the first job</a>
       </div>
     {% endif %}
+
+    {% if is_paginated %}
+      <nav class="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row" aria-label="Job pagination">
+        {% if page_obj.has_previous %}
+          <a href="?page={{ page_obj.previous_page_number }}"
+             class="bw-button bw-button-secondary">
+            Previous
+          </a>
+        {% endif %}
+        <span class="rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)] px-4 py-3 text-sm font-bold bw-muted">
+          Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+        </span>
+        {% if page_obj.has_next %}
+          <a href="?page={{ page_obj.next_page_number }}"
+             class="bw-button bw-button-secondary">
+            Next
+          </a>
+        {% endif %}
+      </nav>
+    {% endif %}
   </div>
 </section>
 

--- a/templates/jobs/job_detail.html
+++ b/templates/jobs/job_detail.html
@@ -7,13 +7,13 @@
     {% if object.company %}
       {% with company_name=object.company.name %}
         {% with page_title=object.title|add:" @ "|add:company_name page_description=company_name|add:" is looking for a "|add:object.title %}
-          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image image_alt=page_title %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image robots=job_robots image_alt=page_title %}
         {% endwith %}
       {% endwith %}
     {% else %}
       {% with company_name=object.company_name %}
         {% with page_title=object.title|add:" @ "|add:company_name page_description=company_name|add:" is looking for a "|add:object.title %}
-          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image image_alt=page_title %}
+          {% include "components/seo_meta.html" with title=page_title description=page_description canonical_path=object.get_absolute_url image=og_image robots=job_robots image_alt=page_title %}
         {% endwith %}
       {% endwith %}
     {% endif %}

--- a/templates/makers/all_makers.html
+++ b/templates/makers/all_makers.html
@@ -6,9 +6,9 @@
 {% block content %}
     <div class="overflow-hidden my-4 bg-white rounded-lg shadow">
         <div class="px-4 py-5 sm:p-6">
-            <p class="text-3xl font-semibold text-gray-800">
+            <h1 class="text-3xl font-semibold text-gray-800">
                 Django Makers
-            </p>
+            </h1>
             <p class="mb-5 text-2xl text-gray-600">
                 Subscribe to know about the coolest Django makers out there.
             </p>

--- a/templates/makers/maker_detail.html
+++ b/templates/makers/maker_detail.html
@@ -63,10 +63,10 @@
                     <div class="sm:col-span-2">
                         <div class="space-y-4">
                             <div class="space-y-1 text-lg font-medium leading-6">
-                                <h3 class="text-4xl font-semibold text-black">
+                                <h1 class="text-4xl font-semibold text-black">
                                     {% if object.first_name %}{{ object.first_name }}{% endif %}
                                     {% if object.last_name %}{{ object.last_name }}{% endif %}
-                                </h3>
+                                </h1>
                                 <ul role="list" class="flex space-x-2">
                                     <li>
                                         {% if object.twitter_handle %}

--- a/templates/projects/all_projects.html
+++ b/templates/projects/all_projects.html
@@ -3,7 +3,8 @@
 {% load widget_tweaks %}
 
 {% block meta %}
-    {% include "components/seo_meta.html" with title="Django Projects | Built with Django" description="Discover real projects and apps built with Django." canonical_path="/projects/" twitter_card="summary" image_alt="Built with Django logo" %}
+    {% firstof canonical_path "/projects/" as projects_canonical_path %}
+    {% include "components/seo_meta.html" with title="Django Projects | Built with Django" description="Discover real projects and apps built with Django." canonical_path=projects_canonical_path robots=robots twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- restrict public project and job detail pages to indexable records while keeping staff/owner access where applicable
- add current-job sitemap filtering, job expiration metadata, stale-job noindex handling, and deterministic robots.txt
- fix project pagination/filter canonical behavior, article listing overlap, and maker page H1 structure

## Tests
- poetry run pytest