### PR TITLE
Reduce noisy project HTML fetch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 ### Fixed
 - Made the bottom-right desktop ad use a solid surface instead of an opacity fade.
+- Reduced noisy Sentry errors when direct project HTML fetches are blocked but the Jina Reader fallback succeeds.
 
 ## [0.4.6] - 2025-12-08
 ### Added

--- a/projects/models.py
+++ b/projects/models.py
@@ -156,7 +156,12 @@ class Project(models.Model):
             html_response.raise_for_status()
             html_content = html_response.text
         except requests.exceptions.RequestException as e:
-            logger.error(f"Error fetching HTML content: {str(e)}")
+            logger.warning(
+                "Direct HTML fetch failed; continuing with Jina Reader fallback",
+                project_id=self.id,
+                url=self.url,
+                error=str(e),
+            )
             html_content = ""
 
         jina_url = f"{settings.JINA_READER_BASE_URL}/{self.url}"

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -177,9 +177,15 @@ class ProjectModelServiceTests(TestCase):
 
         project.refresh_from_db()
         self.assertEqual(project.page_title, "Fallback Readable")
+        self.assertEqual(project.page_description, "Fetched through Jina.")
         self.assertEqual(project.page_content_markdown, "# Fallback")
         self.assertEqual(project.page_content_html, "")
-        logger.warning.assert_called_once()
+        logger.warning.assert_called_once_with(
+            "Direct HTML fetch failed; continuing with Jina Reader fallback",
+            project_id=project.id,
+            url=project.url,
+            error="403 Client Error: Forbidden",
+        )
         logger.error.assert_not_called()
 
 

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -151,6 +151,37 @@ class ProjectModelServiceTests(TestCase):
         self.assertEqual(project.page_content_html, "<html>Project</html>")
         self.assertIsNotNone(project.date_scraped)
 
+    def test_fetch_page_content_treats_direct_html_failure_as_fallback_warning(self):
+        project = Project.objects.create(
+            title="Blocked HTML Project",
+            url="https://blocked-html.example.com",
+            short_description="A project.",
+        )
+        html_response = Mock()
+        html_response.raise_for_status.side_effect = requests.HTTPError("403 Client Error: Forbidden")
+        jina_response = Mock()
+        jina_response.raise_for_status.return_value = None
+        jina_response.json.return_value = {
+            "data": {
+                "title": "Fallback Readable",
+                "description": "Fetched through Jina.",
+                "content": "# Fallback",
+            }
+        }
+
+        with (
+            patch("projects.models.requests.get", side_effect=[html_response, jina_response]),
+            patch("projects.models.logger") as logger,
+        ):
+            self.assertTrue(project.fetch_page_content())
+
+        project.refresh_from_db()
+        self.assertEqual(project.page_title, "Fallback Readable")
+        self.assertEqual(project.page_content_markdown, "# Fallback")
+        self.assertEqual(project.page_content_html, "")
+        logger.warning.assert_called_once()
+        logger.error.assert_not_called()
+
 
 class ProjectTaskObservabilityTests(TestCase):
     def test_fetch_page_content_counts_unexpected_failure(self):


### PR DESCRIPTION
## Summary
- Downgrade direct project HTML fetch failures to fallback warnings when Jina Reader can still fetch content
- Preserve true Jina Reader failures as errors
- Add a regression test for 403 direct HTML responses followed by successful Jina fallback
- Update CHANGELOG.md

## Verification
- .venv/bin/pytest projects/tests.py::ProjectModelServiceTests -q
- .venv/bin/python manage.py check --settings=builtwithdjango.test_settings
- .venv/bin/python manage.py makemigrations --check --dry-run --settings=builtwithdjango.test_settings
- .venv/bin/python -m compileall -q api blog builtwithdjango developers jobs makers newsletter pages podcast projects tools users
- .venv/bin/pytest -q
- npm ci --include=dev
- npm run build

Notes:
- The first local npm build attempt failed because this runtime had npm configured with omit=dev, so cross-env was not installed. After installing dev dependencies explicitly, the build passed.
- npm install reports existing audit warnings; not changed by this PR.