### PR TITLE
Rebuild project like flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Simplified the landing page by removing the hero showcase, proof strip, and quick-link card band.
 - Expanded the home page project and guide sections to show six items and gave guides and jobs full-width sections.
 - Stopped capturing noisy project-like API requests in PostHog request analytics and session recording network logs while keeping explicit like/unlike events.
+- Rebuilt project likes to render counts from annotated project queries and use a single toggle request instead of per-card like API reads.
 
 ### Fixed
 - Made the bottom-right desktop ad use a solid surface instead of an opacity fade.

--- a/api/tests.py
+++ b/api/tests.py
@@ -105,6 +105,60 @@ class LikeApiTests(TestCase):
         self.assertEqual(like.project, self.project)
         self.assertFalse(like.like)
 
+    def test_project_like_toggle_requires_authentication(self):
+        response = self.client.post(
+            reverse("api_project_like_toggle", kwargs={"project_id": self.project.id}),
+            data=json.dumps({"like": True}),
+            content_type="application/json",
+        )
+
+        self.assertIn(response.status_code, {401, 403})
+        self.assertFalse(Like.objects.exists())
+
+    def test_project_like_toggle_creates_like_and_returns_count(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("api_project_like_toggle", kwargs={"project_id": self.project.id}),
+            data=json.dumps({"like": True}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["like"], True)
+        self.assertEqual(response.json()["like_count"], 1)
+        self.assertTrue(Like.objects.get(author=self.user, project=self.project).like)
+
+    def test_project_like_toggle_updates_existing_like_and_returns_count(self):
+        Like.objects.create(author=self.user, project=self.project, like=True)
+        Like.objects.create(author=self.other_user, project=self.project, like=True)
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("api_project_like_toggle", kwargs={"project_id": self.project.id}),
+            data=json.dumps({"like": False}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["like"], False)
+        self.assertEqual(response.json()["like_count"], 1)
+        self.assertFalse(Like.objects.get(author=self.user, project=self.project).like)
+
+    def test_project_like_toggle_toggles_when_like_value_is_omitted(self):
+        Like.objects.create(author=self.user, project=self.project, like=True)
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            reverse("api_project_like_toggle", kwargs={"project_id": self.project.id}),
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["like"], False)
+        self.assertEqual(response.json()["like_count"], 0)
+
 
 class SearchProjectsApiTests(TestCase):
     def test_search_projects_filters_to_public_active_projects_and_limits_results(self):

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 
 from . import views
-from .views import CreateLikeProjectAPIView, CreatePostAPIView, UpdateLikeProjectAPIView
+from .views import CreateLikeProjectAPIView, CreatePostAPIView, ProjectLikeToggleAPIView, UpdateLikeProjectAPIView
 
 urlpatterns = [
     path("like/", CreateLikeProjectAPIView.as_view()),
     path("like/<int:pk>/", UpdateLikeProjectAPIView.as_view()),
+    path("projects/<int:project_id>/like/", ProjectLikeToggleAPIView.as_view(), name="api_project_like_toggle"),
     path("search/projects/", views.search_projects, name="api_search_projects"),
     path("posts/", CreatePostAPIView.as_view(), name="api_create_post"),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -120,9 +120,11 @@ class ProjectLikeToggleAPIView(APIView):
 
     def post(self, request, project_id):
         project = generics.get_object_or_404(Project, pk=project_id)
-        existing_like = Like.objects.filter(author=request.user, project=project).first()
         requested_like = self.get_requested_like(request)
-        like_value = requested_like if requested_like is not None else not bool(existing_like and existing_like.like)
+        like_value = requested_like
+        if like_value is None:
+            existing_like = Like.objects.filter(author=request.user, project=project).first()
+            like_value = not bool(existing_like and existing_like.like)
 
         like, _ = Like.objects.update_or_create(
             author=request.user,

--- a/api/views.py
+++ b/api/views.py
@@ -4,6 +4,7 @@ from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from blog.models import Post
 from builtwithdjango.analytics import capture
@@ -95,6 +96,61 @@ class UpdateLikeProjectAPIView(generics.RetrieveUpdateDestroyAPIView):
                 "like_id": like_id,
             },
             groups={"project": str(project_id)},
+        )
+
+
+class ProjectLikeToggleAPIView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_requested_like(self, request):
+        if "like" not in request.data:
+            return None
+
+        value = request.data["like"]
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized_value = value.lower()
+            if normalized_value in {"true", "1", "yes", "on"}:
+                return True
+            if normalized_value in {"false", "0", "no", "off"}:
+                return False
+
+        return bool(value)
+
+    def post(self, request, project_id):
+        project = generics.get_object_or_404(Project, pk=project_id)
+        existing_like = Like.objects.filter(author=request.user, project=project).first()
+        requested_like = self.get_requested_like(request)
+        like_value = requested_like if requested_like is not None else not bool(existing_like and existing_like.like)
+
+        like, _ = Like.objects.update_or_create(
+            author=request.user,
+            project=project,
+            defaults={"like": like_value},
+        )
+        like_count = Like.objects.filter(project=project, like=True).count()
+
+        capture(
+            request,
+            "project liked" if like.like else "project unliked",
+            properties={
+                "project_id": like.project_id,
+                "author_id": like.author_id,
+                "like_id": like.id,
+                "like_value": like.like,
+                "like_count": like_count,
+            },
+            groups={"project": str(like.project_id)},
+        )
+
+        return Response(
+            {
+                "project": project.id,
+                "like": like.like,
+                "like_count": like_count,
+            },
+            status=status.HTTP_200_OK,
         )
 
 

--- a/frontend/src/controllers/like_controller.js
+++ b/frontend/src/controllers/like_controller.js
@@ -40,6 +40,7 @@ export default class extends Controller {
       })
       .catch((error) => {
         console.log(error);
+        this.showError();
       })
       .finally(() => {
         this.setPending(false);
@@ -59,6 +60,22 @@ export default class extends Controller {
 
     button.disabled = isPending;
     button.classList.toggle("opacity-60", isPending);
+  }
+
+  showError() {
+    const button = this.element.querySelector("button");
+    if (!button) {
+      return;
+    }
+
+    button.classList.add("border-red-600", "text-red-600");
+    button.setAttribute("aria-invalid", "true");
+    button.title = "Could not update like";
+    window.setTimeout(() => {
+      button.classList.remove("border-red-600", "text-red-600");
+      button.removeAttribute("aria-invalid");
+      button.removeAttribute("title");
+    }, 3000);
   }
 
   trackChange(likeValue, previousLikeCount) {

--- a/frontend/src/controllers/like_controller.js
+++ b/frontend/src/controllers/like_controller.js
@@ -1,204 +1,94 @@
 import { Controller } from "@hotwired/stimulus";
-import {enter, leave} from 'el-transition';
+import axios from "axios";
+import { enter, leave } from "el-transition";
 
 export default class extends Controller {
-    static targets = [ "projectId", "numberOfLikes", "currentUser", "modalButton", "modal" ];
+  static targets = ["numberOfLikes", "heart", "modalButton", "modal"];
+  static values = {
+    projectId: Number,
+    count: Number,
+    liked: Boolean,
+    toggleUrl: String,
+  };
 
-    // load all likes
-    connect () {
-      const projectId = this.projectIdTarget.value;
-      const currentUserId = this.currentUserTarget.value;
-      const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+  connect() {
+    this.render();
+  }
 
-      const axios = require('axios');
-      axios({
-        methos: 'get',
-        url: `/api/v1/like?project=${projectId}`,
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrftoken,
-        }
+  modify() {
+    const previousLikeCount = this.countValue;
+    const nextLiked = !this.likedValue;
+    const csrftoken = document.querySelector("[name=csrfmiddlewaretoken]").value;
+
+    this.setPending(true);
+    axios({
+      method: "post",
+      url: this.toggleUrlValue,
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": csrftoken,
+      },
+      data: {
+        like: nextLiked,
+      },
+    })
+      .then((response) => {
+        this.likedValue = response.data.like;
+        this.countValue = response.data.like_count;
+        this.render();
+        this.trackChange(nextLiked, previousLikeCount);
       })
-      .then(function(response) {
-        const arrayWithUsersWithLikes = response.data.filter(like => like.like == true);
-        const arrayOfLikedUserIds = arrayWithUsersWithLikes.map(user => user.author);
-        document.getElementById(`${projectId}_likes`).innerHTML = arrayWithUsersWithLikes.length;
-
-        if (arrayWithUsersWithLikes.length > 0 && arrayOfLikedUserIds.includes(Number(currentUserId))) {
-          document.getElementById(`${projectId}_heart`).classList.add('text-red-600');
-          document.getElementById(`${projectId}_heart`).classList.add('las');
-          document.getElementById(`${projectId}_heart`).classList.add('la-heart');
-          document.getElementById(`${projectId}_heart`).classList.add('block');
-        }
-        else {
-          document.getElementById(`${projectId}_heart`).classList.add('lar');
-          document.getElementById(`${projectId}_heart`).classList.add('la-heart');
-          document.getElementById(`${projectId}_heart`).classList.add('block');
-        }
+      .catch((error) => {
+        console.log(error);
       })
-      .catch(error => console.log(error));
+      .finally(() => {
+        this.setPending(false);
+      });
+  }
+
+  render() {
+    this.numberOfLikesTarget.textContent = this.countValue;
+    this.heartTarget.className = this.likedValue ? "text-red-600 las la-heart block" : "lar la-heart block";
+  }
+
+  setPending(isPending) {
+    const button = this.element.querySelector("button");
+    if (!button) {
+      return;
     }
 
-    // Handle liking
-    modify() {
-      const projectId = this.projectIdTarget.value;
-      const currentUserId = this.currentUserTarget.value;
-      const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
-      const numberOfLikes = Number(document.getElementById(`${projectId}_likes`).textContent);
+    button.disabled = isPending;
+    button.classList.toggle("opacity-60", isPending);
+  }
 
-      // get the like info for the clicked project
-      const axios = require('axios');
-      axios.get(`/api/v1/like?author=${this.currentUserTarget.value}&project=${this.projectIdTarget.value}`)
-        .then(function (response) {
-          var data = response.data;
+  trackChange(likeValue, previousLikeCount) {
+    if (!window.bwdTrack) {
+      return;
+    }
 
-          // if there is no like action happened before we need to create one
-          if (data.length == 0) {
-            axios({
-              method: 'post',
-              url: '/api/v1/like/',
-              headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrftoken,
-              },
-              data: {
-                "author": currentUserId,
-                "project": projectId,
-                "like": true
-              }
-            })
-            .then(function() {
-              document.getElementById(`${projectId}_likes`).textContent = numberOfLikes + 1;
-              document.getElementById(`${projectId}_likes`).removeAttribute("class");
-              document.getElementById(`${projectId}_heart`).classList.add('text-red-600');
-              document.getElementById(`${projectId}_heart`).classList.add('las');
-              document.getElementById(`${projectId}_heart`).classList.add('la-heart');
-              if (window.bwdTrack) {
-                window.bwdTrack('project like changed', {
-                  project_id: projectId,
-                  like_value: true,
-                  previous_like_count: numberOfLikes,
-                  new_like_count: numberOfLikes + 1
-                });
-              }
-            })
-            .catch(function(error) {
-              console.log(error);
-            });
-          }
-          // if the like is currently of, turn it on
-          else if (data[0].like == false) {
-            axios({
-              methos: 'get',
-              url: `/api/v1/like?author=${currentUserId}&project=${projectId}`,
-              headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrftoken,
-              }
-            })
-            .then(function (response) {
-              const id = response.data[0].id;
-              const data = {
-                "author": Number(currentUserId),
-                "project": Number(projectId),
-                "like": true
-              };
-              const headers = {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrftoken,
-              };
-              axios({
-                method: 'put',
-                url: `/api/v1/like/${id}/`,
-                headers,
-                data
-              })
-              .then(function() {
-                document.getElementById(`${projectId}_likes`).innerHTML = "";
-                document.getElementById(`${projectId}_likes`).innerHTML = `${numberOfLikes + 1}`;
-                document.getElementById(`${projectId}_heart`).removeAttribute("class");
-                document.getElementById(`${projectId}_heart`).classList.add('text-red-600');
-                document.getElementById(`${projectId}_heart`).classList.add('las');
-                document.getElementById(`${projectId}_heart`).classList.add('la-heart');
-                if (window.bwdTrack) {
-                  window.bwdTrack('project like changed', {
-                    project_id: projectId,
-                    like_value: true,
-                    previous_like_count: numberOfLikes,
-                    new_like_count: numberOfLikes + 1
-                  });
-                }
-              })
-              .catch(function(error) {
-                console.log(error);
-              });
-            })
-            .catch();
-          }
-          // if the like is on, turn it of
-          else {
-            axios({
-              methos: 'get',
-              url: `/api/v1/like?author=${currentUserId}&project=${projectId}`,
-              headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': csrftoken,
-              }
-            })
-            .then(function (response) {
-              const id = response.data[0].id;
-              axios({
-                method: 'put',
-                url: `/api/v1/like/${id}/`,
-                headers: {
-                  'Content-Type': 'application/json',
-                  'X-CSRFToken': csrftoken,
-                },
-                data: {
-                  "author": currentUserId,
-                  "project": projectId,
-                  "like": false
-                }
-              })
-              .then(function() {
-                document.getElementById(`${projectId}_likes`).textContent = numberOfLikes - 1;
-                document.getElementById(`${projectId}_heart`).removeAttribute("class");
-                document.getElementById(`${projectId}_heart`).classList.add('lar');
-                document.getElementById(`${projectId}_heart`).classList.add('la-heart');
-                if (window.bwdTrack) {
-                  window.bwdTrack('project like changed', {
-                    project_id: projectId,
-                    like_value: false,
-                    previous_like_count: numberOfLikes,
-                    new_like_count: numberOfLikes - 1
-                  });
-                }
-              })
-              .catch(function(error) {
-                console.log(error);
-              });
-            })
-            .catch();
-          }
+    window.bwdTrack("project like changed", {
+      project_id: this.projectIdValue,
+      like_value: likeValue,
+      previous_like_count: previousLikeCount,
+      new_like_count: this.countValue,
+    });
+  }
+
+  toggleModal() {
+    if (this.modalTarget.classList.contains("hidden")) {
+      enter(this.modalTarget);
+      if (window.bwdTrack) {
+        window.bwdTrack("project like auth modal opened", {
+          project_id: this.projectIdValue,
         });
-    }
-
-    // Handle liking for unauthenticated user
-    toggleModal() {
-      if(this.modalTarget.classList.contains('hidden')) {
-        enter(this.modalTarget);
-        if (window.bwdTrack) {
-          window.bwdTrack('project like auth modal opened', {
-            project_id: this.projectIdTarget.value
-          });
-        }
-      } else {
-        leave(this.modalTarget);
-        if (window.bwdTrack) {
-          window.bwdTrack('project like auth modal closed', {
-            project_id: this.projectIdTarget.value
-          });
-        }
+      }
+    } else {
+      leave(this.modalTarget);
+      if (window.bwdTrack) {
+        window.bwdTrack("project like auth modal closed", {
+          project_id: this.projectIdValue,
+        });
       }
     }
+  }
 }

--- a/frontend/src/controllers/like_controller.js
+++ b/frontend/src/controllers/like_controller.js
@@ -36,7 +36,7 @@ export default class extends Controller {
         this.likedValue = response.data.like;
         this.countValue = response.data.like_count;
         this.render();
-        this.trackChange(nextLiked, previousLikeCount);
+        this.trackChange(this.likedValue, previousLikeCount);
       })
       .catch((error) => {
         console.log(error);

--- a/pages/tests.py
+++ b/pages/tests.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from blog.models import Post
 from jobs.models import Job
 from pages.views import HomeView
-from projects.models import Project
+from projects.models import Like, Project
 
 
 class HomeViewTests(TestCase):
@@ -83,3 +83,28 @@ class HomeViewTests(TestCase):
 
         self.assertEqual(len(context["projects"]), 6)
         self.assertEqual(len(context["guides"]), 6)
+
+    def test_home_projects_include_like_metadata(self):
+        user = get_user_model().objects.create_user(username="home-liker", email="home-liker@example.com")
+        other_user = get_user_model().objects.create_user(username="other-home-liker", email="other@example.com")
+        project = Project.objects.create(
+            title="Liked Home Project",
+            url="https://example.com/home-liked",
+            short_description="A liked home project.",
+            published=True,
+            active=True,
+        )
+        Like.objects.create(author=user, project=project, like=True)
+        Like.objects.create(author=other_user, project=project, like=False)
+
+        request = self.factory.get("/")
+        request.user = user
+        view = HomeView()
+        view.setup(request)
+
+        with patch("pages.views.static", return_value="/static/vendors/images/logo.png"):
+            context = view.get_context_data()
+
+        home_project = context["projects"][0]
+        self.assertEqual(home_project.like_count, 1)
+        self.assertTrue(home_project.user_has_liked)

--- a/pages/views.py
+++ b/pages/views.py
@@ -23,6 +23,7 @@ from newsletter.tasks import send_buttondown_newsletter
 from newsletter.views import NewsletterSignupForm
 from podcast.models import Episode
 from projects.models import Project
+from projects.views import with_like_metadata
 
 from .forms import AddNftRequest, ConfirmEmail
 from .models import CistercianDateNftRequest
@@ -40,9 +41,10 @@ class HomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["newsletter_form"] = NewsletterSignupForm
-        context["projects"] = Project.objects.filter(published=True, active=True).order_by("-sponsored", "-date_added")[
-            :6
-        ]
+        context["projects"] = with_like_metadata(
+            Project.objects.filter(published=True, active=True).order_by("-sponsored", "-date_added"),
+            getattr(self.request, "user", None),
+        )[:6]
         context["guides"] = Post.objects.filter(type=Post.TUTORIAL, status=Post.PUBLISHED)[:6]
         context["podcast_episodes"] = Episode.objects.all()[:3]
         filter_date = timezone.now() - timedelta(days=60)

--- a/pages/views.py
+++ b/pages/views.py
@@ -23,7 +23,7 @@ from newsletter.tasks import send_buttondown_newsletter
 from newsletter.views import NewsletterSignupForm
 from podcast.models import Episode
 from projects.models import Project
-from projects.views import with_like_metadata
+from projects.querysets import with_like_metadata
 
 from .forms import AddNftRequest, ConfirmEmail
 from .models import CistercianDateNftRequest

--- a/projects/querysets.py
+++ b/projects/querysets.py
@@ -1,0 +1,14 @@
+from django.db.models import BooleanField, Count, Exists, OuterRef, Q, Value
+
+from .models import Like
+
+
+def with_like_metadata(queryset, user):
+    user_has_liked = Value(False, output_field=BooleanField())
+    if user and user.is_authenticated:
+        user_has_liked = Exists(Like.objects.filter(author=user, project=OuterRef("pk"), like=True))
+
+    return queryset.annotate(
+        like_count=Count("like", filter=Q(like__like=True), distinct=True),
+        user_has_liked=user_has_liked,
+    )

--- a/projects/tests.py
+++ b/projects/tests.py
@@ -290,6 +290,29 @@ class ProjectListViewTests(TestCase):
 
         self.assertEqual(list(view.get_queryset())[:2], [more_liked, less_liked])
 
+    def test_project_list_annotates_like_count_and_user_like_state(self):
+        User = get_user_model()
+        user = User.objects.create_user(username="liker", email="liker@example.com")
+        other_user = User.objects.create_user(username="other-liker", email="other-liker@example.com")
+        project = Project.objects.create(
+            title="Annotated Project",
+            url="https://annotated.example.com",
+            short_description="Annotated.",
+            published=True,
+            active=True,
+        )
+        Like.objects.create(author=user, project=project, like=True)
+        Like.objects.create(author=other_user, project=project, like=False)
+
+        request = RequestFactory().get("/projects/")
+        request.user = user
+        view = ProjectListView()
+        view.setup(request)
+
+        annotated_project = view.get_queryset().get(id=project.id)
+        self.assertEqual(annotated_project.like_count, 1)
+        self.assertTrue(annotated_project.user_has_liked)
+
 
 class LikeMigrationTests(TestCase):
     def test_dedupe_likes_keeps_preferred_like_per_author_project_pair(self):

--- a/projects/views.py
+++ b/projects/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.messages.views import SuccessMessageMixin
-from django.db.models import Count, Q
+from django.db.models import BooleanField, Count, Exists, OuterRef, Q, Value
 from django.templatetags.static import static
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
@@ -13,8 +13,19 @@ from newsletter.forms import NewsletterSignupForm
 from .filters import ProjectFilter
 from .forms import AddProject, ProjectUpdateViewForm
 from .hooks import screenshot_saved
-from .models import Project
+from .models import Like, Project
 from .tasks import fetch_page_content, notify_of_new_project, save_screenshot
+
+
+def with_like_metadata(queryset, user):
+    user_has_liked = Value(False, output_field=BooleanField())
+    if user and user.is_authenticated:
+        user_has_liked = Exists(Like.objects.filter(author=user, project=OuterRef("pk"), like=True))
+
+    return queryset.annotate(
+        like_count=Count("like", filter=Q(like__like=True), distinct=True),
+        user_has_liked=user_has_liked,
+    )
 
 
 class ProjectListView(FilterView):
@@ -24,26 +35,20 @@ class ProjectListView(FilterView):
     paginate_by = 12
 
     def get_queryset(self):
-        queryset = Project.objects.filter(published=True, active=True, might_be_spam=False).order_by(
-            "-sponsored", "-updated_date"
+        queryset = with_like_metadata(
+            Project.objects.filter(published=True, active=True, might_be_spam=False),
+            getattr(self.request, "user", None),
         )
 
         if self.request.GET.get("order_by"):
             ordering = self.request.GET.get("order_by")
 
             if ordering == "like":
-                queryset = (
-                    queryset
-                    # need like_count as an alias for comlex query
-                    # https://stackoverflow.com/questions/39375339/django-complex-annotations-require-an-alias-what-is-alias-here
-                    .annotate(like__count=Count("like", filter=Q(like__like=True))).order_by(
-                        "-sponsored", f"-like__count"
-                    )
-                )
+                return queryset.order_by("-sponsored", "-like_count")
             else:
-                queryset = queryset.order_by("-sponsored", "-updated_date")
+                return queryset.order_by("-sponsored", "-updated_date")
 
-        return queryset
+        return queryset.order_by("-sponsored", "-updated_date")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -63,7 +68,12 @@ class ProjectListView(FilterView):
 class InactiveProjectListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
     model = Project
     template_name = "projects/all_inactive_projects.html"
-    queryset = Project.objects.filter(published=True, active=False, might_be_spam=False)
+
+    def get_queryset(self):
+        return with_like_metadata(
+            Project.objects.filter(published=True, active=False, might_be_spam=False),
+            self.request.user,
+        )
 
     def test_func(self):
         return self.request.user.is_staff
@@ -74,7 +84,7 @@ class ProjectDetailView(DetailView):
     template_name = "projects/project_detail.html"
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = with_like_metadata(super().get_queryset(), self.request.user)
         if self.request.user.is_staff:
             return queryset
 

--- a/projects/views.py
+++ b/projects/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.messages.views import SuccessMessageMixin
-from django.db.models import BooleanField, Count, Exists, OuterRef, Q, Value
+from django.db.models import Q
 from django.templatetags.static import static
 from django.urls import reverse, reverse_lazy
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
@@ -13,19 +13,9 @@ from newsletter.forms import NewsletterSignupForm
 from .filters import ProjectFilter
 from .forms import AddProject, ProjectUpdateViewForm
 from .hooks import screenshot_saved
-from .models import Like, Project
+from .models import Project
+from .querysets import with_like_metadata
 from .tasks import fetch_page_content, notify_of_new_project, save_screenshot
-
-
-def with_like_metadata(queryset, user):
-    user_has_liked = Value(False, output_field=BooleanField())
-    if user and user.is_authenticated:
-        user_has_liked = Exists(Like.objects.filter(author=user, project=OuterRef("pk"), like=True))
-
-    return queryset.annotate(
-        like_count=Count("like", filter=Q(like__like=True), distinct=True),
-        user_has_liked=user_has_liked,
-    )
 
 
 class ProjectListView(FilterView):

--- a/templates/components/project-likes.html
+++ b/templates/components/project-likes.html
@@ -1,9 +1,12 @@
 {% load static %}
 {% load widget_tweaks %}
 
-<div data-controller="like" class="inline-flex">
-  <input type="hidden" data-like-target="projectId" value="{{ site.id }}" />
-  <input type="hidden" data-like-target="currentUser" value="{{ user.id }}" />
+<div data-controller="like"
+     data-like-project-id-value="{{ site.id }}"
+     data-like-count-value="{{ site.like_count|default:0 }}"
+     data-like-liked-value="{{ site.user_has_liked|yesno:'true,false' }}"
+     data-like-toggle-url-value="{% url 'api_project_like_toggle' site.id %}"
+     class="inline-flex">
   {% csrf_token %}
   {% if user.is_authenticated %}
     <button data-action="click->like#modify"
@@ -13,8 +16,8 @@
             class="bw-icon-button gap-1"
             type="button"
             aria-label="Like {{ site.title }}">
-      <span class="text-sm font-black" data-like-target="numberOfLikes" id="{{ site.id }}_likes"></span>
-      <i id="{{ site.id }}_heart" aria-hidden="true"></i>
+      <span class="text-sm font-black" data-like-target="numberOfLikes">{{ site.like_count|default:0 }}</span>
+      <i data-like-target="heart" aria-hidden="true"></i>
     </button>
   {% else %}
     <button data-action="click->like#toggleModal"
@@ -24,8 +27,8 @@
             class="bw-icon-button gap-1"
             type="button"
             aria-label="Like {{ site.title }}">
-      <span class="text-sm font-black" data-like-target="numberOfLikes" id="{{ site.id }}_likes"></span>
-      <i id="{{ site.id }}_heart" aria-hidden="true"></i>
+      <span class="text-sm font-black" data-like-target="numberOfLikes">{{ site.like_count|default:0 }}</span>
+      <i data-like-target="heart" aria-hidden="true"></i>
     </button>
     <div data-like-target="modal"
          class="fixed inset-0 z-50 hidden overflow-y-auto"

--- a/templates/components/project-likes.html
+++ b/templates/components/project-likes.html
@@ -17,7 +17,9 @@
             type="button"
             aria-label="Like {{ site.title }}">
       <span class="text-sm font-black" data-like-target="numberOfLikes">{{ site.like_count|default:0 }}</span>
-      <i data-like-target="heart" aria-hidden="true"></i>
+      <i data-like-target="heart"
+         class="{% if site.user_has_liked %}text-red-600 las{% else %}lar{% endif %} la-heart block"
+         aria-hidden="true"></i>
     </button>
   {% else %}
     <button data-action="click->like#toggleModal"
@@ -28,7 +30,9 @@
             type="button"
             aria-label="Like {{ site.title }}">
       <span class="text-sm font-black" data-like-target="numberOfLikes">{{ site.like_count|default:0 }}</span>
-      <i data-like-target="heart" aria-hidden="true"></i>
+      <i data-like-target="heart"
+         class="{% if site.user_has_liked %}text-red-600 las{% else %}lar{% endif %} la-heart block"
+         aria-hidden="true"></i>
     </button>
     <div data-like-target="modal"
          class="fixed inset-0 z-50 hidden overflow-y-auto"


### PR DESCRIPTION
## Summary
- render project like counts and viewer state from annotated project queries instead of per-card API reads
- add an authenticated project-like toggle endpoint that returns the updated state/count
- simplify the Stimulus like controller to render from server data and make one POST per click

## Production/backfill notes
- no schema or data migration added
- no backfill needed for this change; existing Like rows remain the source of truth

## Verification
- uv run --with pytest --with pytest-django --with django --with djangorestframework --with django-filter --with django-model-utils --with django-autoslug --with django-environ --with django-widget-tweaks --with django-q2 --with requests --with markdown --with cloudinary --with django-webpack-loader --with pillow --with posthog --with structlog --with django-structlog --with sentry-sdk --with structlog-sentry --with pydantic-ai-slim[openrouter] --with logfire --with django-allauth --with django-oauth-toolkit --with django-anymail --with django-storages --with boto3 --with stripe pytest
- npm run build