### PR TITLE
Handle duplicate signup username races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Rebuilt project likes to render counts from annotated project queries and use a single toggle request instead of per-card like API reads.
 
 ### Fixed
+- Returned a signup form error instead of a server error when duplicate username submissions race validation.
 - Made the bottom-right desktop ad use a solid surface instead of an opacity fade.
 - Reduced noisy Sentry errors when direct project HTML fetches are blocked but the Jina Reader fallback succeeds.
 

--- a/builtwithdjango/urls.py
+++ b/builtwithdjango/urls.py
@@ -21,6 +21,7 @@ from django.contrib.sitemaps.views import sitemap
 from django.urls import include, path
 from django.views.generic import TemplateView
 
+from users.views import CustomSignupView
 from users.webhooks import stripe_webhook
 
 from .sitemaps import sitemaps
@@ -39,6 +40,7 @@ urlpatterns = (
         path("podcast/", include("podcast.urls")),
         path("developers/", include("developers.urls")),
         path("tools/", include("tools.urls")),
+        path("users/signup/", CustomSignupView.as_view(), name="account_signup"),
         path("users/", include("allauth.urls")),
         path("users/", include("users.urls")),
         path("uses", TemplateView.as_view(template_name="pages/uses.html"), name="uses"),

--- a/users/tests.py
+++ b/users/tests.py
@@ -48,10 +48,46 @@ class SignupTests(TestCase):
         self.assertIn("username", form.errors)
         self.assertEqual(get_user_model().objects.filter(username="race-user").count(), 1)
 
+    def test_duplicate_email_save_race_returns_form_error(self):
+        request = RequestFactory().post(reverse("account_signup"))
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        form = CustomUserCreationForm(
+            data={
+                "username": "email-race-user",
+                "email": "email-race-user@example.com",
+                "password1": "A-very-long-test-pass123",
+                "password2": "A-very-long-test-pass123",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        try_save = patch.object(
+            form, "try_save", side_effect=IntegrityError('duplicate key value violates unique constraint "unique_verified_email"')
+        )
+        try_save.start()
+        self.addCleanup(try_save.stop)
+
+        view = CustomSignupView()
+        view.setup(request)
+        response = view.form_valid(form)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("email", form.errors)
+
     def test_duplicate_signup_field_detects_postgres_username_constraint(self):
         error = IntegrityError('duplicate key value violates unique constraint "auth_user_username_key"')
 
         self.assertEqual(duplicate_signup_field(error), "username")
+
+    def test_duplicate_signup_field_detects_sqlite_username_constraint(self):
+        error = IntegrityError("UNIQUE constraint failed: auth_user.username")
+
+        self.assertEqual(duplicate_signup_field(error), "username")
+
+    def test_duplicate_signup_field_detects_email_constraint(self):
+        error = IntegrityError('duplicate key value violates unique constraint "unique_verified_email"')
+
+        self.assertEqual(duplicate_signup_field(error), "email")
 
 
 def stripe_event(price_id, metadata, customer_id="cus_test", subscription_id=None):

--- a/users/tests.py
+++ b/users/tests.py
@@ -4,13 +4,16 @@ from unittest.mock import patch
 
 import stripe
 from django.contrib.auth import get_user_model
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError, connection, transaction
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 from builtwithdjango.stripe_client import get_or_create_stripe_customer_id, get_stripe_price_id
 from jobs.models import Job
+from users.forms import CustomUserCreationForm
+from users.views import CustomSignupView, duplicate_signup_field
 from users.webhooks import get_checkout_distinct_id, handle_stripe_event
 
 PRICE_IDS = {
@@ -18,6 +21,37 @@ PRICE_IDS = {
     "django_devs": "price_devs",
     "job": "price_job",
 }
+
+
+class SignupTests(TestCase):
+    def test_duplicate_username_validation_race_returns_form_error(self):
+        request = RequestFactory().post(reverse("account_signup"))
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        form = CustomUserCreationForm(
+            data={
+                "username": "race-user",
+                "email": "race-user@example.com",
+                "password1": "A-very-long-test-pass123",
+                "password2": "A-very-long-test-pass123",
+            }
+        )
+        self.assertTrue(form.is_valid())
+
+        get_user_model().objects.create_user(username="race-user", email="existing-race-user@example.com")
+
+        view = CustomSignupView()
+        view.setup(request)
+        response = view.form_valid(form)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("username", form.errors)
+        self.assertEqual(get_user_model().objects.filter(username="race-user").count(), 1)
+
+    def test_duplicate_signup_field_detects_postgres_username_constraint(self):
+        error = IntegrityError('duplicate key value violates unique constraint "auth_user_username_key"')
+
+        self.assertEqual(duplicate_signup_field(error), "username")
 
 
 def stripe_event(price_id, metadata, customer_id="cus_test", subscription_id=None):

--- a/users/views.py
+++ b/users/views.py
@@ -61,6 +61,7 @@ class CustomSignupView(SignupView):
             return response
 
         try:
+            # Keep this completion flow in sync with allauth 65.17.0's SignupView.form_valid when upgrading allauth.
             redirect_url = self.get_success_url()
             return flows.signup.complete_signup(
                 self.request,

--- a/users/views.py
+++ b/users/views.py
@@ -1,9 +1,7 @@
 import stripe
 from allauth.account.adapter import get_adapter
-from allauth.account.internal import flows
 from allauth.account.models import EmailAddress
 from allauth.account.views import SignupView
-from allauth.core.exceptions import ImmediateHttpResponse
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ImproperlyConfigured
@@ -47,7 +45,7 @@ class CustomSignupView(SignupView):
     def form_valid(self, form):
         try:
             with transaction.atomic():
-                self.user, response = form.try_save(self.request)
+                return super().form_valid(form)
         except IntegrityError as error:
             field = duplicate_signup_field(error)
             if field is None:
@@ -56,21 +54,6 @@ class CustomSignupView(SignupView):
             form.add_error(field, DUPLICATE_SIGNUP_ERRORS[field])
             logger.warning(f"Rejected duplicate signup {field} after validation: {str(error)}")
             return self.form_invalid(form)
-
-        if response:
-            return response
-
-        try:
-            # Keep this completion flow in sync with allauth 65.17.0's SignupView.form_valid when upgrading allauth.
-            redirect_url = self.get_success_url()
-            return flows.signup.complete_signup(
-                self.request,
-                user=self.user,
-                redirect_url=redirect_url,
-                by_passkey=form.by_passkey,
-            )
-        except ImmediateHttpResponse as error:
-            return error.response
 
 
 class ProfileUpdateForm(LoginRequiredMixin, SuccessMessageMixin, UpdateView):

--- a/users/views.py
+++ b/users/views.py
@@ -24,11 +24,22 @@ from .models import CustomUser
 
 logger = get_builtwithdjango_logger(__name__)
 
+DUPLICATE_SIGNUP_ERRORS = {
+    "email": "A user with that email already exists.",
+    "username": "A user with that username already exists.",
+}
+
 
 def duplicate_signup_field(error):
     message = str(error).lower()
     if "auth_user_username_key" in message or "auth_user.username" in message:
         return "username"
+    if (
+        "unique_verified_email" in message
+        or "account_emailaddress_email" in message
+        or "account_emailaddress.email" in message
+    ):
+        return "email"
     return None
 
 
@@ -42,7 +53,7 @@ class CustomSignupView(SignupView):
             if field is None:
                 raise
 
-            form.add_error(field, "A user with that username already exists.")
+            form.add_error(field, DUPLICATE_SIGNUP_ERRORS[field])
             logger.warning(f"Rejected duplicate signup {field} after validation: {str(error)}")
             return self.form_invalid(form)
 

--- a/users/views.py
+++ b/users/views.py
@@ -1,9 +1,13 @@
 import stripe
 from allauth.account.adapter import get_adapter
+from allauth.account.internal import flows
 from allauth.account.models import EmailAddress
+from allauth.account.views import SignupView
+from allauth.core.exceptions import ImmediateHttpResponse
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ImproperlyConfigured
+from django.db import IntegrityError, transaction
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views.generic import TemplateView, UpdateView
@@ -19,6 +23,42 @@ from .models import CustomUser
 # See ACCOUNT_FORMS in settings.py for custom form configuration
 
 logger = get_builtwithdjango_logger(__name__)
+
+
+def duplicate_signup_field(error):
+    message = str(error).lower()
+    if "auth_user_username_key" in message or "auth_user.username" in message:
+        return "username"
+    return None
+
+
+class CustomSignupView(SignupView):
+    def form_valid(self, form):
+        try:
+            with transaction.atomic():
+                self.user, response = form.try_save(self.request)
+        except IntegrityError as error:
+            field = duplicate_signup_field(error)
+            if field is None:
+                raise
+
+            form.add_error(field, "A user with that username already exists.")
+            logger.warning(f"Rejected duplicate signup {field} after validation: {str(error)}")
+            return self.form_invalid(form)
+
+        if response:
+            return response
+
+        try:
+            redirect_url = self.get_success_url()
+            return flows.signup.complete_signup(
+                self.request,
+                user=self.user,
+                redirect_url=redirect_url,
+                by_passkey=form.by_passkey,
+            )
+        except ImmediateHttpResponse as error:
+            return error.response
 
 
 class ProfileUpdateForm(LoginRequiredMixin, SuccessMessageMixin, UpdateView):


### PR DESCRIPTION
## Summary
- Route `/users/signup/` through a local `CustomSignupView` before allauth's URL include.
- Convert duplicate username database races during signup into a form error instead of a 500.
- Add regression coverage for the Postgres `auth_user_username_key` error and the validation/save race.
- Update `CHANGELOG.md`.

## Verification
- `DJANGO_SETTINGS_MODULE=builtwithdjango.test_settings uv run python manage.py check --settings=builtwithdjango.test_settings`
- `DJANGO_SETTINGS_MODULE=builtwithdjango.test_settings uv run python manage.py makemigrations --check --dry-run --settings=builtwithdjango.test_settings`
- `uv run python -m compileall -q api blog builtwithdjango developers jobs makers newsletter pages podcast projects tools users`
- `DJANGO_SETTINGS_MODULE=builtwithdjango.test_settings uv run pytest -q`
- `env -u NODE_ENV npm ci && env -u NODE_ENV npm run build`
