### PR TITLE
[Tests] Streamline PGSandbox Test Runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 
 test-pgsandbox:
 	@test -n "$$DATABASE_URL" || (echo "DATABASE_URL is required. Create a pgsandbox database, then run: DATABASE_URL='postgresql://...' make test-pgsandbox"; exit 1)
-	@pgsandbox_database_url=$$(printf '%s' "$$DATABASE_URL" | sed -e 's/@localhost:/@host.docker.internal:/' -e 's/@127\.0\.0\.1:/@host.docker.internal:/' -e 's/@\[::1\]:/@host.docker.internal:/'); \
+	@pgsandbox_database_url=$$(printf '%s' "$$DATABASE_URL" | sed -e 's/@localhost\([:/]\)/@host.docker.internal\1/' -e 's/@127\.0\.0\.1\([:/]\)/@host.docker.internal\1/' -e 's/@\[::1\]\([:/]\)/@host.docker.internal\1/'); \
 	docker compose run --rm --no-deps \
 		-e DJANGO_TEST_USE_DATABASE_URL=true \
 		-e DJANGO_TEST_REUSE_EXISTING_DATABASE=true \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: serve manage makemigrations shell test test-pgsandbox bash test-webhook stripe-listen restart-worker prod-shell
+
 serve:
 	docker compose up -d --build
 	docker compose logs -f backend
@@ -12,7 +14,16 @@ shell:
 	docker compose run --rm backend python ./manage.py shell_plus --ipython
 
 test:
-	docker compose run --rm backend pytest
+	docker compose run --rm backend pytest $(ARGS)
+
+test-pgsandbox:
+	@test -n "$$DATABASE_URL" || (echo "DATABASE_URL is required. Create a pgsandbox database, then run: DATABASE_URL='postgresql://...' make test-pgsandbox"; exit 1)
+	@pgsandbox_database_url=$$(printf '%s' "$$DATABASE_URL" | sed -e 's/@localhost:/@host.docker.internal:/' -e 's/@127\.0\.0\.1:/@host.docker.internal:/'); \
+	docker compose run --rm --no-deps \
+		-e DJANGO_TEST_USE_DATABASE_URL=true \
+		-e DJANGO_TEST_REUSE_EXISTING_DATABASE=true \
+		-e DATABASE_URL="$$pgsandbox_database_url" \
+		backend pytest --reuse-db $(ARGS)
 
 bash:
 	docker compose run --rm backend bash

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 
 test-pgsandbox:
 	@test -n "$$DATABASE_URL" || (echo "DATABASE_URL is required. Create a pgsandbox database, then run: DATABASE_URL='postgresql://...' make test-pgsandbox"; exit 1)
-	@pgsandbox_database_url=$$(printf '%s' "$$DATABASE_URL" | sed -e 's/@localhost:/@host.docker.internal:/' -e 's/@127\.0\.0\.1:/@host.docker.internal:/'); \
+	@pgsandbox_database_url=$$(printf '%s' "$$DATABASE_URL" | sed -e 's/@localhost:/@host.docker.internal:/' -e 's/@127\.0\.0\.1:/@host.docker.internal:/' -e 's/@\[::1\]:/@host.docker.internal:/'); \
 	docker compose run --rm --no-deps \
 		-e DJANGO_TEST_USE_DATABASE_URL=true \
 		-e DJANGO_TEST_REUSE_EXISTING_DATABASE=true \

--- a/README.md
+++ b/README.md
@@ -12,6 +12,28 @@ You can submit your project here -> https://builtwithdjango.com/projects/new/
 
 If you have any ideas, please open up an issue, and I'll try to implement it when I can.
 
+## Testing
+
+Run the default test suite with Docker:
+
+```bash
+make test
+```
+
+Pass pytest arguments with `ARGS`:
+
+```bash
+make test ARGS="api/tests.py -v"
+```
+
+To run against an isolated Postgres database from `pgsandbox-mcp`, create a sandbox database, then pass its connection string as `DATABASE_URL`:
+
+```bash
+DATABASE_URL="postgresql://..." make test-pgsandbox
+```
+
+The `test-pgsandbox` target rewrites `localhost` and `127.0.0.1` database hosts to `host.docker.internal` for the backend container, uses `builtwithdjango.test_settings`, and runs pytest with `--reuse-db` because sandbox roles do not create separate Django test databases.
+
 ## Observability
 
 Production Sentry is enabled when `SENTRY_DSN` is set and `SENTRY_ENABLED` is true. `SENTRY_ENABLED` defaults to true only when `ENV=prod`. The default config captures all errors, warning-and-above logs, sampled traces, trace-lifecycle profiles, application metrics, and AI spans for Pydantic AI.

--- a/builtwithdjango/test_settings.py
+++ b/builtwithdjango/test_settings.py
@@ -53,6 +53,8 @@ if env_flag("DJANGO_TEST_USE_DATABASE_URL"):
     DATABASES = {
         "default": environ.Env.db_url_config(os.environ["DATABASE_URL"]),
     }
+    if env_flag("DJANGO_TEST_REUSE_EXISTING_DATABASE"):
+        DATABASES["default"]["TEST"] = {"NAME": DATABASES["default"]["NAME"]}
 else:
     DATABASES = {
         "default": {
@@ -60,9 +62,6 @@ else:
             "NAME": ":memory:",
         }
     }
-
-if env_flag("DJANGO_TEST_REUSE_EXISTING_DATABASE"):
-    DATABASES["default"]["TEST"] = {"NAME": DATABASES["default"]["NAME"]}
 
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",

--- a/builtwithdjango/test_settings.py
+++ b/builtwithdjango/test_settings.py
@@ -1,10 +1,16 @@
 import os
 import tempfile
 
+import environ
+
 
 def set_test_env(name, value):
     if os.environ.get(name) in {None, "", "''", '""'}:
         os.environ[name] = value
+
+
+def env_flag(name):
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 set_test_env("ENV", "test")
@@ -43,12 +49,20 @@ DEBUG = False
 ALLOWED_HOSTS = ["testserver", "localhost", "127.0.0.1"]
 CSRF_TRUSTED_ORIGINS = ["http://localhost:8000"]
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
+if env_flag("DJANGO_TEST_USE_DATABASE_URL"):
+    DATABASES = {
+        "default": environ.Env.db_url_config(os.environ["DATABASE_URL"]),
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    }
+
+if env_flag("DJANGO_TEST_REUSE_EXISTING_DATABASE"):
+    DATABASES["default"]["TEST"] = {"NAME": DATABASES["default"]["NAME"]}
 
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",


### PR DESCRIPTION
## Summary
- add an opt-in test settings path for running pytest against DATABASE_URL
- add `make test-pgsandbox` for pgsandbox-mcp Postgres databases
- document the default and pgsandbox test workflows

## Validation
- `git diff --check`
- `DATABASE_URL="postgresql://..." make test-pgsandbox ARGS="-q"` -> 98 passed, 37 warnings
