### PR TITLE
[API] Add Blog Post CRUD Endpoints

### DIFF
--- a/.agents/skills/blog-post-management-api/SKILL.md
+++ b/.agents/skills/blog-post-management-api/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: blog-post-management-api
+description: Use when an AI agent needs to manage Built With Django blog posts through the site API, including creating, reading, listing, updating, or deleting posts. Covers the superuser-token-only CRUD endpoints under /api/v1/posts/, required headers, payload fields, status/type/level choices, tag behavior, safety checks, and troubleshooting for permission or validation errors.
+---
+
+# Blog Post Management API
+
+Use the Built With Django blog post API to manage posts programmatically. These endpoints are for automation by trusted agents only and require a token/API key that belongs to a Django superuser.
+
+## Auth
+
+Always send the superuser token in the DRF token header:
+
+```bash
+Authorization: Token $SUPERUSER_API_KEY
+```
+
+Do not use session cookies, browser login state, or a staff-only token. The API intentionally accepts `TokenAuthentication` only and checks `user.is_superuser`.
+
+Keep tokens out of source files, issue comments, logs, and PR descriptions. Read them from the runtime environment or a secret manager. If a token is missing or belongs to a non-superuser, stop and ask for a proper superuser API token instead of trying to work around the permission failure.
+
+## Endpoints
+
+Base path:
+
+```text
+/api/v1/posts/
+```
+
+Supported operations:
+
+| Operation | Method and path | Notes |
+|---|---|---|
+| List posts | `GET /api/v1/posts/` | Returns drafts and published posts visible to the superuser token. |
+| Filter posts | `GET /api/v1/posts/?status=PB&type=TUTORIAL&level=BEGINNER` | Supported filters: `status`, `type`, `level`. |
+| Create post | `POST /api/v1/posts/` | Assigns `author` from the superuser token. |
+| Read post | `GET /api/v1/posts/{id}/` | Returns one post by numeric id. |
+| Update post | `PATCH /api/v1/posts/{id}/` | Prefer `PATCH` for partial edits. |
+| Replace post | `PUT /api/v1/posts/{id}/` | Use only when sending all required fields. |
+| Delete post | `DELETE /api/v1/posts/{id}/` | Permanently deletes the post. Read first unless the user gave an exact id. |
+
+## Fields
+
+Writable fields:
+
+| Field | Values |
+|---|---|
+| `title` | Post title. |
+| `description` | Optional summary text. |
+| `slug` | URL slug. Check existing posts before changing it. |
+| `content` | Full post body. |
+| `status` | `DR` for draft, `PB` for published. |
+| `type` | `TUTORIAL`, `INTERVIEW`, `UPDATE`, or `ARTICLE`. |
+| `level` | `BEGINNER`, `INTERMEDIATE`, or `ADVANCED`. |
+| `unsplashID` | Optional Unsplash image id. |
+| `tags` | Comma-separated string, for example `Django, Testing`. |
+
+Read-only response fields include `id`, `author`, `created`, `modified`, and `tag_list`.
+
+Tag behavior:
+
+- On create, non-empty `tags` creates or reuses tags by slug and attaches them.
+- On update, non-empty `tags` replaces the full tag set.
+- Omitted `tags` leaves tags unchanged.
+- Blank `tags` is treated as no-op. Do not send `tags: ""` expecting tags to be cleared.
+
+## Request Examples
+
+Set these first:
+
+```bash
+export SITE_BASE_URL="https://builtwithdjango.com"
+export SUPERUSER_API_KEY="..."
+```
+
+List posts:
+
+```bash
+curl -sS "$SITE_BASE_URL/api/v1/posts/" \
+  -H "Authorization: Token $SUPERUSER_API_KEY"
+```
+
+Create a draft:
+
+```bash
+curl -sS -X POST "$SITE_BASE_URL/api/v1/posts/" \
+  -H "Authorization: Token $SUPERUSER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Testing Django Agents",
+    "description": "A short guide to testing agent-managed Django workflows.",
+    "slug": "testing-django-agents",
+    "content": "Draft content goes here.",
+    "status": "DR",
+    "type": "TUTORIAL",
+    "level": "INTERMEDIATE",
+    "tags": "Django, Testing, Agents",
+    "unsplashID": "example-image-id"
+  }'
+```
+
+Update selected fields:
+
+```bash
+curl -sS -X PATCH "$SITE_BASE_URL/api/v1/posts/123/" \
+  -H "Authorization: Token $SUPERUSER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Updated title",
+    "status": "PB"
+  }'
+```
+
+Replace tags:
+
+```bash
+curl -sS -X PATCH "$SITE_BASE_URL/api/v1/posts/123/" \
+  -H "Authorization: Token $SUPERUSER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"tags": "Django, API"}'
+```
+
+Delete a post:
+
+```bash
+curl -sS -i -X DELETE "$SITE_BASE_URL/api/v1/posts/123/" \
+  -H "Authorization: Token $SUPERUSER_API_KEY"
+```
+
+## Agent Workflow
+
+1. Confirm the target environment and load `SITE_BASE_URL` and `SUPERUSER_API_KEY` from trusted configuration.
+2. For updates or deletes, fetch the post first and verify the `id`, `title`, `slug`, and `status`.
+3. Prefer draft status (`DR`) for newly generated content unless the user explicitly asks to publish.
+4. Use `PATCH` for edits so omitted fields remain unchanged.
+5. After create, update, or delete, read back the relevant list or detail endpoint to confirm the final state.
+6. Report the post id, slug, status, and changed fields. Do not print the token.
+
+## Troubleshooting
+
+- `401` or `403`: token is missing, invalid, not sent as `Authorization: Token ...`, or does not belong to a superuser.
+- `400`: check required fields and allowed choices for `status`, `type`, and `level`.
+- `404`: the post id does not exist, or the path is not `/api/v1/posts/{id}/`.
+- Session-authenticated requests are expected to fail. Use the superuser token header.

--- a/.agents/skills/blog-post-management-api/SKILL.md
+++ b/.agents/skills/blog-post-management-api/SKILL.md
@@ -62,7 +62,7 @@ Tag behavior:
 - On create, non-empty `tags` creates or reuses tags by slug and attaches them.
 - On update, non-empty `tags` replaces the full tag set.
 - Omitted `tags` leaves tags unchanged.
-- Blank `tags` is treated as no-op. Do not send `tags: ""` expecting tags to be cleared.
+- Blank, whitespace-only, or comma-only `tags` is treated as no-op. Do not send `tags: ""` expecting tags to be cleared.
 
 ## Request Examples
 

--- a/.agents/skills/blog-post-management-api/agents/openai.yaml
+++ b/.agents/skills/blog-post-management-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blog Post API"
+  short_description: "Manage blog posts through the superuser API"
+  default_prompt: "Use $blog-post-management-api to create, read, update, or delete blog posts with the superuser token API."

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -33,6 +33,7 @@ class PostSerializer(serializers.ModelSerializer):
         model = Post
         fields = (
             "id",
+            "author",
             "title",
             "description",
             "slug",
@@ -41,39 +42,46 @@ class PostSerializer(serializers.ModelSerializer):
             "content",
             "status",
             "type",
+            "level",
+            "unsplashID",
             "created",
             "modified",
         )
-        read_only_fields = ("id", "created", "modified", "tag_list")
+        read_only_fields = ("id", "author", "created", "modified", "tag_list")
 
     def create(self, validated_data):
-        from django.contrib.auth import get_user_model
+        tags_string = validated_data.pop("tags", None)
 
-        # Extract tags string if provided
-        tags_string = validated_data.pop("tags", "")
+        if "author" not in validated_data:
+            request = self.context.get("request")
+            user = getattr(request, "user", None)
+            if not getattr(user, "is_authenticated", False):
+                raise serializers.ValidationError("Authenticated author is required.")
+            validated_data["author"] = user
 
-        # Set author to first superuser
-        User = get_user_model()
-        author = User.objects.filter(is_superuser=True).first()
-        if not author:
-            raise serializers.ValidationError("No superuser found in the system. Please create one first.")
-
-        validated_data["author"] = author
-
-        # Set default level if not provided
         if "level" not in validated_data:
             validated_data["level"] = Post.BEGINNER
 
-        # Create the post
         post = Post.objects.create(**validated_data)
-
-        # Process tags if provided
-        if tags_string:
-            tag_names = [name.strip() for name in tags_string.split(",") if name.strip()]
-            for tag_name in tag_names:
-                tag, created = Tag.objects.get_or_create(
-                    name=tag_name, defaults={"slug": tag_name.lower().replace(" ", "-")}
-                )
-                post.tags.add(tag)
+        self.set_tags(post, tags_string)
 
         return post
+
+    def update(self, instance, validated_data):
+        tags_string = validated_data.pop("tags", None)
+        post = super().update(instance, validated_data)
+        self.set_tags(post, tags_string)
+        return post
+
+    def set_tags(self, post, tags_string):
+        if tags_string is None:
+            return
+
+        post.tags.clear()
+        tag_names = [name.strip() for name in tags_string.split(",") if name.strip()]
+        for tag_name in tag_names:
+            tag, _created = Tag.objects.get_or_create(
+                name=tag_name,
+                defaults={"slug": tag_name.lower().replace(" ", "-")},
+            )
+            post.tags.add(tag)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -72,8 +72,11 @@ class PostSerializer(serializers.ModelSerializer):
         if not tags_string:
             return
 
-        post.tags.clear()
         tag_names = [name.strip() for name in tags_string.split(",") if name.strip()]
+        if not tag_names:
+            return
+
+        post.tags.clear()
         for tag_name in tag_names:
             slug = tag_name.lower().replace(" ", "-")
             tag, _created = Tag.objects.get_or_create(slug=slug, defaults={"name": tag_name})

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -75,7 +75,6 @@ class PostSerializer(serializers.ModelSerializer):
         post.tags.clear()
         tag_names = [name.strip() for name in tags_string.split(",") if name.strip()]
         for tag_name in tag_names:
-            tag = Tag.objects.filter(name__iexact=tag_name).first()
-            if tag is None:
-                tag = Tag.objects.create(name=tag_name, slug=tag_name.lower().replace(" ", "-"))
+            slug = tag_name.lower().replace(" ", "-")
+            tag, _created = Tag.objects.get_or_create(slug=slug, defaults={"name": tag_name})
             post.tags.add(tag)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -55,8 +55,8 @@ class PostSerializer(serializers.ModelSerializer):
         if "author" not in validated_data:
             request = self.context.get("request")
             user = getattr(request, "user", None)
-            if not getattr(user, "is_authenticated", False):
-                raise serializers.ValidationError("Authenticated author is required.")
+            if not getattr(user, "is_authenticated", False) or not getattr(user, "is_superuser", False):
+                raise serializers.ValidationError("Superuser author is required.")
             validated_data["author"] = user
 
         if "level" not in validated_data:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -51,13 +51,8 @@ class PostSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         tags_string = validated_data.pop("tags", None)
-
-        if "author" not in validated_data:
-            request = self.context.get("request")
-            user = getattr(request, "user", None)
-            if not getattr(user, "is_authenticated", False) or not getattr(user, "is_superuser", False):
-                raise serializers.ValidationError("Superuser author is required.")
-            validated_data["author"] = user
+        if not getattr(validated_data.get("author"), "is_superuser", False):
+            raise serializers.ValidationError("Superuser author is required.")
 
         if "level" not in validated_data:
             validated_data["level"] = Post.BEGINNER
@@ -74,14 +69,13 @@ class PostSerializer(serializers.ModelSerializer):
         return post
 
     def set_tags(self, post, tags_string):
-        if tags_string is None:
+        if not tags_string:
             return
 
         post.tags.clear()
         tag_names = [name.strip() for name in tags_string.split(",") if name.strip()]
         for tag_name in tag_names:
-            tag, _created = Tag.objects.get_or_create(
-                name=tag_name,
-                defaults={"slug": tag_name.lower().replace(" ", "-")},
-            )
+            tag = Tag.objects.filter(name__iexact=tag_name).first()
+            if tag is None:
+                tag = Tag.objects.create(name=tag_name, slug=tag_name.lower().replace(" ", "-"))
             post.tags.add(tag)

--- a/api/tests.py
+++ b/api/tests.py
@@ -316,9 +316,10 @@ class BlogPostApiTests(TestCase):
         self.assertEqual(post.level, Post.ADVANCED)
         self.assertEqual(set(post.tags.values_list("name", flat=True)), {"Django", "Agents"})
 
-    def test_update_post_with_blank_tags_clears_tags(self):
+    def test_update_post_with_blank_tags_leaves_tags_unchanged(self):
         post = self.make_post(title="Tagged Guide", slug="tagged-guide")
-        post.tags.add(Tag.objects.create(name="Old", slug="old"))
+        tag = Tag.objects.create(name="Old", slug="old")
+        post.tags.add(tag)
 
         response = self.client.patch(
             reverse("api_post_detail", args=[post.id]),
@@ -328,7 +329,23 @@ class BlogPostApiTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(post.tags.exists())
+        self.assertEqual(list(post.tags.all()), [tag])
+
+    def test_update_post_reuses_case_variant_tag_names(self):
+        django_tag = Tag.objects.create(name="Django", slug="django")
+        post = self.make_post(title="Case Tags", slug="case-tags")
+
+        response = self.client.patch(
+            reverse("api_post_detail", args=[post.id]),
+            data=json.dumps({"tags": "DJANGO, Agents"}),
+            content_type="application/json",
+            **self.auth_headers(self.admin_token),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(set(post.tags.values_list("name", flat=True)), {"Django", "Agents"})
+        self.assertIn(django_tag, post.tags.all())
+        self.assertEqual(Tag.objects.filter(slug="django").count(), 1)
 
     def test_delete_post_removes_post(self):
         post = self.make_post(title="Delete Me", slug="delete-me")

--- a/api/tests.py
+++ b/api/tests.py
@@ -3,6 +3,7 @@ import json
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
+from rest_framework.authtoken.models import Token
 
 from blog.models import Post, Tag
 from projects.models import Like, Project
@@ -199,13 +200,23 @@ class SearchProjectsApiTests(TestCase):
         self.assertEqual(response.json(), [])
 
 
-class CreatePostApiTests(TestCase):
-    def setUp(self):
+class BlogPostApiTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
         User = get_user_model()
-        self.user = User.objects.create_user(username="writer", email="writer@example.com", password="password")
-        self.admin = User.objects.create_superuser(username="admin", email="admin@example.com", password="password")
+        cls.user = User.objects.create_user(username="writer", email="writer@example.com", password="password")
+        cls.staff_user = User.objects.create_user(
+            username="staff-writer",
+            email="staff-writer@example.com",
+            password="password",
+            is_staff=True,
+        )
+        cls.admin = User.objects.create_superuser(username="admin", email="admin@example.com", password="password")
+        cls.user_token = Token.objects.create(user=cls.user)
+        cls.staff_token = Token.objects.create(user=cls.staff_user)
+        cls.admin_token = Token.objects.create(user=cls.admin)
 
-    def test_create_post_requires_admin_user(self):
+    def test_post_api_requires_superuser_token(self):
         payload = self.post_payload()
 
         anonymous_response = self.client.post(
@@ -215,28 +226,103 @@ class CreatePostApiTests(TestCase):
         )
         self.assertIn(anonymous_response.status_code, {401, 403})
 
-        self.client.force_login(self.user)
-        user_response = self.client.post(
+        user_token_response = self.client.post(
+            reverse("api_create_post"),
+            data=json.dumps(payload),
+            content_type="application/json",
+            **self.auth_headers(self.user_token),
+        )
+        self.assertEqual(user_token_response.status_code, 403)
+
+        staff_token_response = self.client.post(
+            reverse("api_create_post"),
+            data=json.dumps(payload),
+            content_type="application/json",
+            **self.auth_headers(self.staff_token),
+        )
+        self.assertEqual(staff_token_response.status_code, 403)
+
+        self.client.force_login(self.admin)
+        session_response = self.client.post(
             reverse("api_create_post"),
             data=json.dumps(payload),
             content_type="application/json",
         )
-        self.assertEqual(user_response.status_code, 403)
+        self.assertIn(session_response.status_code, {401, 403})
 
-    def test_create_post_assigns_superuser_author_and_creates_tags(self):
-        self.client.force_login(self.admin)
+        self.assertFalse(Post.objects.filter(slug="testing-django").exists())
 
+    def test_create_post_assigns_token_user_author_and_creates_tags(self):
         response = self.client.post(
             reverse("api_create_post"),
             data=json.dumps(self.post_payload()),
             content_type="application/json",
+            **self.auth_headers(self.admin_token),
         )
 
         self.assertEqual(response.status_code, 201)
         post = Post.objects.get(slug="testing-django")
         self.assertEqual(post.author, self.admin)
+        self.assertEqual(post.level, Post.INTERMEDIATE)
+        self.assertEqual(post.unsplashID, "testing-image")
         self.assertEqual(set(post.tags.values_list("name", flat=True)), {"Django", "Testing"})
         self.assertTrue(Tag.objects.filter(name="Django", slug="django").exists())
+        self.assertEqual(response.json()["author"], self.admin.id)
+
+    def test_list_posts_returns_all_posts_to_superuser_token(self):
+        draft = self.make_post(title="Draft Guide", slug="draft-guide", status=Post.DRAFT)
+        published = self.make_post(title="Published Guide", slug="published-guide", status=Post.PUBLISHED)
+
+        response = self.client.get(reverse("api_create_post"), **self.auth_headers(self.admin_token))
+
+        self.assertEqual(response.status_code, 200)
+        post_ids = {post["id"] for post in response.json()}
+        self.assertEqual(post_ids, {draft.id, published.id})
+
+    def test_retrieve_post_returns_post_detail_to_superuser_token(self):
+        post = self.make_post(title="Agent Guide", slug="agent-guide")
+        post.tags.add(Tag.objects.create(name="Agents", slug="agents"))
+
+        response = self.client.get(reverse("api_post_detail", args=[post.id]), **self.auth_headers(self.admin_token))
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["id"], post.id)
+        self.assertEqual(data["title"], "Agent Guide")
+        self.assertEqual(data["tag_list"], [{"id": post.tags.first().id, "name": "Agents", "slug": "agents"}])
+
+    def test_update_post_changes_fields_and_replaces_tags(self):
+        post = self.make_post(title="Old Guide", slug="old-guide", status=Post.DRAFT)
+        post.tags.add(Tag.objects.create(name="Old", slug="old"))
+
+        response = self.client.patch(
+            reverse("api_post_detail", args=[post.id]),
+            data=json.dumps(
+                {
+                    "title": "Updated Guide",
+                    "status": Post.PUBLISHED,
+                    "level": Post.ADVANCED,
+                    "tags": "Django, Agents",
+                }
+            ),
+            content_type="application/json",
+            **self.auth_headers(self.admin_token),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        post.refresh_from_db()
+        self.assertEqual(post.title, "Updated Guide")
+        self.assertEqual(post.status, Post.PUBLISHED)
+        self.assertEqual(post.level, Post.ADVANCED)
+        self.assertEqual(set(post.tags.values_list("name", flat=True)), {"Django", "Agents"})
+
+    def test_delete_post_removes_post(self):
+        post = self.make_post(title="Delete Me", slug="delete-me")
+
+        response = self.client.delete(reverse("api_post_detail", args=[post.id]), **self.auth_headers(self.admin_token))
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Post.objects.filter(id=post.id).exists())
 
     def post_payload(self):
         return {
@@ -247,4 +333,23 @@ class CreatePostApiTests(TestCase):
             "content": "Use tests to protect behavior.",
             "status": Post.PUBLISHED,
             "type": Post.TUTORIAL,
+            "level": Post.INTERMEDIATE,
+            "unsplashID": "testing-image",
         }
+
+    def make_post(self, **kwargs):
+        defaults = {
+            "title": "Testing Django",
+            "description": "A guide to testing Django projects.",
+            "slug": "testing-django",
+            "content": "Use tests to protect behavior.",
+            "status": Post.PUBLISHED,
+            "type": Post.TUTORIAL,
+            "level": Post.BEGINNER,
+            "author": self.admin,
+        }
+        defaults.update(kwargs)
+        return Post.objects.create(**defaults)
+
+    def auth_headers(self, token):
+        return {"HTTP_AUTHORIZATION": f"Token {token.key}"}

--- a/api/tests.py
+++ b/api/tests.py
@@ -316,6 +316,20 @@ class BlogPostApiTests(TestCase):
         self.assertEqual(post.level, Post.ADVANCED)
         self.assertEqual(set(post.tags.values_list("name", flat=True)), {"Django", "Agents"})
 
+    def test_update_post_with_blank_tags_clears_tags(self):
+        post = self.make_post(title="Tagged Guide", slug="tagged-guide")
+        post.tags.add(Tag.objects.create(name="Old", slug="old"))
+
+        response = self.client.patch(
+            reverse("api_post_detail", args=[post.id]),
+            data=json.dumps({"tags": ""}),
+            content_type="application/json",
+            **self.auth_headers(self.admin_token),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(post.tags.exists())
+
     def test_delete_post_removes_post(self):
         post = self.make_post(title="Delete Me", slug="delete-me")
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -317,19 +317,21 @@ class BlogPostApiTests(TestCase):
         self.assertEqual(set(post.tags.values_list("name", flat=True)), {"Django", "Agents"})
 
     def test_update_post_with_blank_tags_leaves_tags_unchanged(self):
-        post = self.make_post(title="Tagged Guide", slug="tagged-guide")
-        tag = Tag.objects.create(name="Old", slug="old")
-        post.tags.add(tag)
+        for index, tags_value in enumerate(["", "  ", ",, ,"]):
+            with self.subTest(tags_value=tags_value):
+                post = self.make_post(title=f"Tagged Guide {index}", slug=f"tagged-guide-{index}")
+                tag = Tag.objects.create(name=f"Old {index}", slug=f"old-{index}")
+                post.tags.add(tag)
 
-        response = self.client.patch(
-            reverse("api_post_detail", args=[post.id]),
-            data=json.dumps({"tags": ""}),
-            content_type="application/json",
-            **self.auth_headers(self.admin_token),
-        )
+                response = self.client.patch(
+                    reverse("api_post_detail", args=[post.id]),
+                    data=json.dumps({"tags": tags_value}),
+                    content_type="application/json",
+                    **self.auth_headers(self.admin_token),
+                )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(post.tags.all()), [tag])
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(list(post.tags.all()), [tag])
 
     def test_update_post_reuses_case_variant_tag_names(self):
         django_tag = Tag.objects.create(name="Django", slug="django")

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,12 +1,19 @@
 from django.urls import path
 
 from . import views
-from .views import CreateLikeProjectAPIView, CreatePostAPIView, ProjectLikeToggleAPIView, UpdateLikeProjectAPIView
+from .views import (
+    BlogPostListCreateAPIView,
+    BlogPostRetrieveUpdateDestroyAPIView,
+    CreateLikeProjectAPIView,
+    ProjectLikeToggleAPIView,
+    UpdateLikeProjectAPIView,
+)
 
 urlpatterns = [
     path("like/", CreateLikeProjectAPIView.as_view()),
     path("like/<int:pk>/", UpdateLikeProjectAPIView.as_view()),
     path("projects/<int:project_id>/like/", ProjectLikeToggleAPIView.as_view(), name="api_project_like_toggle"),
     path("search/projects/", views.search_projects, name="api_search_projects"),
-    path("posts/", CreatePostAPIView.as_view(), name="api_create_post"),
+    path("posts/", BlogPostListCreateAPIView.as_view(), name="api_create_post"),
+    path("posts/<int:pk>/", BlogPostRetrieveUpdateDestroyAPIView.as_view(), name="api_post_detail"),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,8 +1,9 @@
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics, status
+from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
+from rest_framework.permissions import AllowAny, BasePermission, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -11,6 +12,11 @@ from builtwithdjango.analytics import capture
 from projects.models import Like, Project
 
 from .serializers import LikeSerializer, LikeSerializerNoId, PostSerializer
+
+
+class IsSuperuser(BasePermission):
+    def has_permission(self, request, view):
+        return bool(request.user and request.user.is_authenticated and request.user.is_superuser)
 
 
 class CreateLikeProjectAPIView(generics.ListCreateAPIView):
@@ -194,18 +200,20 @@ def search_projects(request):
     return Response(results)
 
 
-class CreatePostAPIView(generics.CreateAPIView):
+class BlogPostListCreateAPIView(generics.ListCreateAPIView):
     """
-    Create a new blog post.
-    Only superusers can create posts.
+    List and create blog posts for token-authenticated superusers.
     """
 
-    queryset = Post.objects.all()
+    queryset = Post.objects.select_related("author").prefetch_related("tags")
     serializer_class = PostSerializer
-    permission_classes = [IsAdminUser]
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsSuperuser]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["status", "type", "level"]
 
     def perform_create(self, serializer):
-        post = serializer.save()
+        post = serializer.save(author=self.request.user)
         capture(
             self.request,
             "post created",
@@ -215,5 +223,49 @@ class CreatePostAPIView(generics.CreateAPIView):
                 "post_slug": post.slug,
                 "post_status": post.status,
                 "post_type": post.type,
+            },
+        )
+
+
+class BlogPostRetrieveUpdateDestroyAPIView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    Retrieve, update, and delete blog posts for token-authenticated superusers.
+    """
+
+    queryset = Post.objects.select_related("author").prefetch_related("tags")
+    serializer_class = PostSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsSuperuser]
+
+    def perform_update(self, serializer):
+        post = serializer.save()
+        capture(
+            self.request,
+            "post updated",
+            properties={
+                "post_id": post.id,
+                "post_title": post.title,
+                "post_slug": post.slug,
+                "post_status": post.status,
+                "post_type": post.type,
+            },
+        )
+
+    def perform_destroy(self, instance):
+        post_id = instance.id
+        post_title = instance.title
+        post_slug = instance.slug
+        post_status = instance.status
+        post_type = instance.type
+        instance.delete()
+        capture(
+            self.request,
+            "post deleted",
+            properties={
+                "post_id": post_id,
+                "post_title": post_title,
+                "post_slug": post_slug,
+                "post_status": post_status,
+                "post_type": post_type,
             },
         )


### PR DESCRIPTION
## Summary
- Add token-only superuser CRUD endpoints for blog posts under `/api/v1/posts/`.
- Assign created blog posts to the authenticated superuser token owner.
- Extend post serialization to include `author`, `level`, `unsplashID`, and tag replacement on update.
- Cover anonymous, staff-token, non-superuser-token, and session-auth rejection paths.

## Testing
- `poetry run pytest api -q`
- `poetry run python manage.py check --settings=builtwithdjango.test_settings`
- `poetry run black --check api/serializers.py api/views.py api/urls.py api/tests.py`

## Post-Deploy Monitoring & Validation
- Watch application logs for `403`, `401`, and `5xx` responses on `/api/v1/posts/` and `/api/v1/posts/<id>/`.
- Validate one superuser token can list/create/update/delete a draft post in production or staging.
- Confirm browser session-only requests to `/api/v1/posts/` remain denied.
- Healthy signal: authenticated superuser-token requests return expected `2xx` responses and denied requests return `401`/`403`.
- Failure signal: non-superuser token or session-only requests can mutate posts, or superuser-token requests fail unexpectedly.
- Rollback trigger: disable agent use of the endpoint and revert this PR if authorization is bypassed or post mutations fail.
- Validation window: first 24 hours after deploy; owner: site maintainer.
