### PR TITLE
[UI] Harden Django Showcase UI

### DIFF
--- a/builtwithdjango/analytics.py
+++ b/builtwithdjango/analytics.py
@@ -24,6 +24,7 @@ _MAX_HEADER_LENGTH = 1000
 
 def posthog_template_context(request):
     return {
+        "app_environment": getattr(settings, "ENVIRONMENT", ""),
         "posthog_enabled": getattr(settings, "POSTHOG_ENABLED", False),
         "posthog_api_key": getattr(settings, "POSTHOG_API_KEY", ""),
         "posthog_api_host": getattr(settings, "POSTHOG_HOST", "https://us.i.posthog.com"),

--- a/frontend/src/application/hotwire.js
+++ b/frontend/src/application/hotwire.js
@@ -3,7 +3,6 @@ import "../styles/tailwind.css";
 
 import { Application } from "@hotwired/stimulus";
 import { definitionsFromContext } from "@hotwired/stimulus-webpack-helpers";
-import Dropdown from 'stimulus-dropdown';
 import Reveal from 'stimulus-reveal-controller';
 
 
@@ -12,5 +11,4 @@ const application = Application.start();
 const context = require.context("../controllers", true, /\.js$/);
 application.load(definitionsFromContext(context));
 
-application.register('dropdown', Dropdown);
 application.register('reveal', Reveal);

--- a/frontend/src/controllers/dropdown_controller.js
+++ b/frontend/src/controllers/dropdown_controller.js
@@ -10,6 +10,7 @@ export default class extends Dropdown {
 
   disconnect() {
     document.removeEventListener("keydown", this.boundCloseOnEscape);
+    super.disconnect?.();
   }
 
   toggle(event) {

--- a/frontend/src/controllers/dropdown_controller.js
+++ b/frontend/src/controllers/dropdown_controller.js
@@ -9,8 +9,10 @@ export default class extends Dropdown {
   }
 
   disconnect() {
+    if (typeof super.disconnect === "function") {
+      super.disconnect();
+    }
     document.removeEventListener("keydown", this.boundCloseOnEscape);
-    super.disconnect?.();
   }
 
   toggle(event) {

--- a/frontend/src/controllers/dropdown_controller.js
+++ b/frontend/src/controllers/dropdown_controller.js
@@ -1,0 +1,44 @@
+import Dropdown from "stimulus-dropdown";
+
+export default class extends Dropdown {
+  connect() {
+    super.connect();
+    this.boundCloseOnEscape = this.closeOnEscape.bind(this);
+    document.addEventListener("keydown", this.boundCloseOnEscape);
+    this.setExpanded(false);
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.boundCloseOnEscape);
+  }
+
+  toggle(event) {
+    super.toggle(event);
+    window.requestAnimationFrame(() => {
+      this.setExpanded(!this.menuTarget.classList.contains("hidden"));
+    });
+  }
+
+  hide(event) {
+    super.hide(event);
+    if (!this.element.contains(event.target)) {
+      this.setExpanded(false);
+    }
+  }
+
+  closeOnEscape(event) {
+    if (event.key !== "Escape" || this.menuTarget.classList.contains("hidden")) return;
+
+    this.leave();
+    this.setExpanded(false);
+    this.triggerElement?.focus();
+  }
+
+  setExpanded(isExpanded) {
+    this.triggerElement?.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+  }
+
+  get triggerElement() {
+    return this.element.querySelector("[aria-expanded]");
+  }
+}

--- a/frontend/src/controllers/exit_intent_controller.js
+++ b/frontend/src/controllers/exit_intent_controller.js
@@ -1,32 +1,31 @@
 import { Controller } from "@hotwired/stimulus";
-import {enter, leave} from 'el-transition';
+import { enter, leave } from "el-transition";
 
 export default class extends Controller {
-    static targets = [ "modal", "closeButton" ];
+  static targets = ["modal", "closeButton"];
 
-    initialize() {
-      this.numOfOpens = 0;
-    }
+  initialize() {
+    this.numOfOpens = 0;
+  }
 
-    openModal(event) {
-      if(this.modalTarget.classList.contains('hidden') && this.numOfOpens === 0) {
-        if (!event.toElement && !event.relatedTarget) {
-          setTimeout(() => {
-            enter(this.modalTarget);
-            this.numOfOpens++;
-            if (window.bwdTrack) {
-              window.bwdTrack('exit intent modal opened');
-            }
-          }, 1000);
-        }
+  openModal(event) {
+    if (this.modalTarget.classList.contains("hidden") && this.numOfOpens === 0) {
+      if (!event.toElement && !event.relatedTarget) {
+        setTimeout(() => {
+          enter(this.modalTarget);
+          this.numOfOpens++;
+          if (window.bwdTrack) {
+            window.bwdTrack("exit intent modal opened");
+          }
+        }, 1000);
       }
     }
+  }
 
-    closeModal() {
-        console.log("not hidden");
-        leave(this.modalTarget);
-        if (window.bwdTrack) {
-          window.bwdTrack('exit intent modal closed');
-        }
+  closeModal() {
+    leave(this.modalTarget);
+    if (window.bwdTrack) {
+      window.bwdTrack("exit intent modal closed");
     }
+  }
 }

--- a/frontend/src/controllers/html_formatter_controller.js
+++ b/frontend/src/controllers/html_formatter_controller.js
@@ -117,8 +117,15 @@ export default class extends Controller {
     textarea.style.top = '-9999px';
     document.body.appendChild(textarea);
     textarea.select();
-    document.execCommand('copy');
-    textarea.remove();
+
+    try {
+      const copied = document.execCommand('copy');
+      if (!copied) {
+        throw new Error('Copy command was rejected');
+      }
+    } finally {
+      textarea.remove();
+    }
   }
 
   clearResult() {

--- a/frontend/src/controllers/html_formatter_controller.js
+++ b/frontend/src/controllers/html_formatter_controller.js
@@ -1,46 +1,54 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = [ "input", "result", "submitButton", "copyButton" ];
+  static targets = [ "input", "result", "submitButton", "copyButton", "status" ];
 
   formatHTML() {
+    const input = this.inputTarget.value.trim();
+    if (!input) {
+      this.setError('Paste a Django template before formatting.');
+      return;
+    }
+
     this.setLoading(true);
+    this.setStatus('Formatting template...');
 
     const formData = new FormData();
-    formData.append('html_string', this.inputTarget.value);
+    formData.append('html_string', input);
 
     fetch('/tools/api/format-html/', {
       method: 'POST',
       body: formData,
     })
-    .then(response => {
+    .then(async response => {
       if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || `Request failed with status ${response.status}`);
       }
       return response.json();
     })
     .then(data => {
       if (data.formatted_html) {
         this.resultTarget.value = data.formatted_html;
-        this.copyButtonTarget.classList.remove('hidden');
+        this.copyButtonTarget.disabled = false;
+        this.resetCopyButton();
+        this.setStatus('Formatted HTML is ready.');
         this.capture('html formatted', {
-          input_length: this.inputTarget.value.length,
+          input_length: input.length,
           output_length: data.formatted_html.length
         });
       } else if (data.error) {
-        this.resultTarget.value = 'Error: ' + data.error;
-        this.copyButtonTarget.classList.add('hidden');
+        this.setError(data.error);
         this.capture('html formatter failed', {
-          input_length: this.inputTarget.value.length,
+          input_length: input.length,
           error: data.error
         });
       }
     })
     .catch(error => {
-      this.resultTarget.value = 'Error: ' + error;
-      this.copyButtonTarget.classList.add('hidden');
+      this.setError(error.message || 'Could not format HTML. Check your connection and try again.');
       this.capture('html formatter failed', {
-        input_length: this.inputTarget.value.length,
+        input_length: input.length,
         error: error.message
       });
     })
@@ -49,10 +57,24 @@ export default class extends Controller {
     });
   }
 
-  copy() {
-    navigator.clipboard.writeText(this.resultTarget.value);
-    this.copyButtonTarget.classList.replace("bg-blue-500", "bg-green-500");
+  async copy() {
+    if (!this.resultTarget.value) {
+      this.setError('Format HTML before copying.');
+      return;
+    }
+
+    try {
+      await this.copyText(this.resultTarget.value);
+    } catch (error) {
+      this.setError('Could not copy automatically. Select the result and copy it manually.');
+      this.capture('formatted html copy failed', {
+        error: error.message
+      });
+      return;
+    }
+
     this.copyButtonTarget.textContent = "Copied!";
+    this.setStatus('Formatted HTML copied.');
     this.capture('formatted html copied', {
       output_length: this.resultTarget.value.length
     });
@@ -60,20 +82,49 @@ export default class extends Controller {
   }
 
   resetCopyButton() {
-    this.copyButtonTarget.classList.replace("bg-green-500", "bg-blue-500");
     this.copyButtonTarget.textContent = "Copy";
   }
 
   setLoading(isLoading) {
     this.submitButtonTarget.disabled = isLoading;
     this.submitButtonTarget.textContent = isLoading ? 'Formatting...' : 'Format HTML';
-    this.submitButtonTarget.classList.toggle('opacity-50', isLoading);
-    this.submitButtonTarget.classList.toggle('cursor-not-allowed', isLoading);
+  }
+
+  setStatus(message) {
+    this.statusTarget.textContent = message;
+    this.statusTarget.classList.add('bw-muted');
+    this.statusTarget.classList.remove('bw-status-error');
+  }
+
+  setError(message) {
+    this.resultTarget.value = '';
+    this.copyButtonTarget.disabled = true;
+    this.statusTarget.textContent = message;
+    this.statusTarget.classList.remove('bw-muted');
+    this.statusTarget.classList.add('bw-status-error');
+  }
+
+  async copyText(value) {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(value);
+      return;
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.top = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    textarea.remove();
   }
 
   clearResult() {
     this.resultTarget.value = '';
-    this.copyButtonTarget.classList.add('hidden');
+    this.copyButtonTarget.disabled = true;
+    this.setStatus('Result cleared.');
     this.capture('html formatter cleared');
   }
 

--- a/frontend/src/controllers/infinite_scroll_controller.js
+++ b/frontend/src/controllers/infinite_scroll_controller.js
@@ -51,7 +51,6 @@ export default class extends Controller {
             }
         })
         .catch((error) => {
-            console.error('Error:', error);
             if (window.bwdTrack) {
                 window.bwdTrack('infinite scroll failed', {
                     url,

--- a/frontend/src/controllers/like_controller.js
+++ b/frontend/src/controllers/like_controller.js
@@ -39,7 +39,7 @@ export default class extends Controller {
         this.trackChange(this.likedValue, previousLikeCount);
       })
       .catch((error) => {
-        console.log(error);
+        void error;
         this.showError();
       })
       .finally(() => {

--- a/frontend/src/controllers/like_controller.js
+++ b/frontend/src/controllers/like_controller.js
@@ -38,8 +38,7 @@ export default class extends Controller {
         this.render();
         this.trackChange(this.likedValue, previousLikeCount);
       })
-      .catch((error) => {
-        void error;
+      .catch(() => {
         this.showError();
       })
       .finally(() => {

--- a/frontend/src/controllers/search_controller.js
+++ b/frontend/src/controllers/search_controller.js
@@ -68,10 +68,10 @@ export default class extends Controller {
     updateSelection(results) {
         results.forEach((result, index) => {
             if (index === this.selectedIndex) {
-                result.classList.add("bg-gray-50");
+                result.classList.add("bw-search-result--active");
                 result.scrollIntoView({ block: "nearest" });
             } else {
-                result.classList.remove("bg-gray-50");
+                result.classList.remove("bw-search-result--active");
             }
         });
     }
@@ -116,7 +116,6 @@ export default class extends Controller {
                 has_results: data.length > 0
             });
         } catch (error) {
-            console.error("Search error:", error);
             this.capture("project search failed", {
                 query_length: query.length,
                 error: error.message
@@ -128,7 +127,7 @@ export default class extends Controller {
     showResults(results) {
         if (!results.length) {
             const emptyState = document.createElement("div");
-            emptyState.className = "p-4 text-sm text-gray-500";
+            emptyState.className = "bw-search-empty";
             emptyState.textContent = "No projects found";
             this.resultsTarget.replaceChildren(emptyState);
             this.resultsTarget.classList.remove("hidden");
@@ -146,14 +145,14 @@ export default class extends Controller {
         link.dataset.analyticsProjectId = String(result.id || "");
         link.dataset.analyticsProjectTitle = result.title || "";
         link.dataset.analyticsProjectSlug = result.slug || "";
-        link.className = "flex flex-col p-4 border-b border-gray-100 hover:bg-gray-50 last:border-b-0";
+        link.className = "bw-search-result";
 
         const title = document.createElement("div");
-        title.className = "font-medium text-gray-900";
+        title.className = "bw-search-result__title";
         title.textContent = result.title || "";
 
         const description = document.createElement("div");
-        description.className = "text-sm text-gray-500";
+        description.className = "bw-search-result__description";
         description.textContent = result.short_description || "";
 
         link.append(title, description);

--- a/frontend/src/controllers/secret_key_controller.js
+++ b/frontend/src/controllers/secret_key_controller.js
@@ -98,8 +98,15 @@ export default class extends Controller {
         textarea.style.top = "-9999px";
         document.body.appendChild(textarea);
         textarea.select();
-        document.execCommand("copy");
-        textarea.remove();
+
+        try {
+            const copied = document.execCommand("copy");
+            if (!copied) {
+                throw new Error("Copy command was rejected");
+            }
+        } finally {
+            textarea.remove();
+        }
     }
 
     getCookie(name) {

--- a/frontend/src/controllers/secret_key_controller.js
+++ b/frontend/src/controllers/secret_key_controller.js
@@ -1,54 +1,105 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-    static targets = [ "output", "copyButton" ];
+    static targets = [ "output", "copyButton", "generateButton", "status" ];
     static values = { url: String };
 
-    generate() {
+    async generate() {
         if (!this.urlValue) {
-            console.error('URL is undefined');
-            this.outputTarget.value = 'Error: URL is not set';
+            this.setStatus("Secret key generation is not configured. Try again later.", true);
             return;
         }
 
-        fetch(this.urlValue, {
-            method: 'POST',
-            headers: {
-                'X-CSRFToken': this.getCookie('csrftoken'),
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({}),
-        })
-        .then(response => {
+        this.setGenerating(true);
+        this.setStatus("Generating a new secret key...");
+
+        try {
+            const response = await fetch(this.urlValue, {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': this.getCookie('csrftoken'),
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({}),
+            });
+
             if (!response.ok) {
-                throw new Error('Network response was not ok');
+                throw new Error(`Request failed with status ${response.status}`);
             }
-            return response.json();
-        })
-        .then(data => {
+
+            const data = await response.json();
+            if (!data.secret_key) {
+                throw new Error("The server did not return a secret key");
+            }
+
             this.outputTarget.value = data.secret_key;
-            this.resetCopyButton();  // Reset the copy button when new secret is generated
+            this.copyButtonTarget.disabled = false;
+            this.resetCopyButton();
+            this.setStatus("Secret key generated. Copy it before leaving this page.");
             this.capture('django secret generated');
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            this.outputTarget.value = 'An error occurred: ' + error.message;
+        } catch (error) {
+            this.outputTarget.value = "";
+            this.copyButtonTarget.disabled = true;
+            this.setStatus("Could not generate a secret key. Check your connection and try again.", true);
             this.capture('django secret generation failed', {
                 error: error.message
             });
-        });
+        } finally {
+            this.setGenerating(false);
+        }
     }
 
-    copy() {
-        navigator.clipboard.writeText(this.outputTarget.value);
-        this.copyButtonTarget.classList.replace("bg-green-600", "bg-blue-600");
+    async copy() {
+        if (!this.outputTarget.value) {
+            this.setStatus("Generate a secret key before copying.", true);
+            return;
+        }
+
+        try {
+            await this.copyText(this.outputTarget.value);
+        } catch (error) {
+            this.setStatus("Could not copy automatically. Select the key and copy it manually.", true);
+            this.capture('django secret copy failed', {
+                error: error.message
+            });
+            return;
+        }
+
         this.copyButtonTarget.textContent = "Copied";
+        this.setStatus("Secret key copied.");
         this.capture('django secret copied');
     }
 
     resetCopyButton() {
-        this.copyButtonTarget.classList.replace("bg-blue-600", "bg-green-600");
         this.copyButtonTarget.textContent = "Copy";
+    }
+
+    setGenerating(isGenerating) {
+        this.generateButtonTarget.disabled = isGenerating;
+        this.generateButtonTarget.textContent = isGenerating ? "Generating..." : "Generate Secret Key";
+    }
+
+    setStatus(message, isError = false) {
+        this.statusTarget.textContent = message;
+        this.statusTarget.classList.toggle("bw-muted", !isError);
+        this.statusTarget.classList.toggle("bw-status-error", isError);
+    }
+
+    async copyText(value) {
+        if (navigator.clipboard && window.isSecureContext) {
+            await navigator.clipboard.writeText(value);
+            return;
+        }
+
+        const textarea = document.createElement("textarea");
+        textarea.value = value;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.top = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        textarea.remove();
     }
 
     getCookie(name) {

--- a/frontend/src/sentry.js
+++ b/frontend/src/sentry.js
@@ -1,5 +1,3 @@
-import * as Sentry from "@sentry/browser";
-
 const SENSITIVE_QUERY_PARTS = [
   "token",
   "auth",
@@ -70,9 +68,12 @@ function scrubEvent(event) {
   return event;
 }
 
-const config = readSentryConfig();
+async function initializeSentry() {
+  const config = readSentryConfig();
 
-if (config.enabled && config.dsn) {
+  if (!config.enabled || !config.dsn) return;
+
+  const Sentry = await import(/* webpackChunkName: "sentry" */ "@sentry/browser");
   const tracePropagationTargets =
     Array.isArray(config.tracePropagationTargets) && config.tracePropagationTargets.length
       ? config.tracePropagationTargets
@@ -107,3 +108,7 @@ if (config.enabled && config.dsn) {
     Sentry.setUser(config.user);
   }
 }
+
+initializeSentry().catch((error) => {
+  void error;
+});

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -169,11 +169,17 @@
       box-shadow 150ms var(--bw-ease);
   }
 
-	  .bw-button-primary {
-	    background: var(--bw-primary-dark);
-	    color: oklch(98% 0.01 118);
-	    box-shadow: 0 8px 18px oklch(27% 0.09 154 / 0.18);
-	  }
+  .bw-button:disabled {
+    cursor: not-allowed;
+    opacity: 0.58;
+    transform: none;
+  }
+
+  .bw-button-primary {
+    background: var(--bw-primary-dark);
+    color: oklch(98% 0.01 118);
+    box-shadow: 0 8px 18px oklch(27% 0.09 154 / 0.18);
+  }
 
   .bw-button-primary:hover {
     background: var(--bw-primary);
@@ -201,6 +207,10 @@
   .bw-button-accent:hover {
     background: oklch(78% 0.17 92);
     transform: translateY(-1px);
+  }
+
+  .bw-button:disabled:hover {
+    transform: none;
   }
 
   .bw-kicker {
@@ -259,6 +269,8 @@
 
   .bw-brand {
     display: inline-flex;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     align-items: center;
     gap: 0.65rem;
     color: var(--bw-ink);
@@ -273,7 +285,7 @@
 
   .bw-nav-link {
     display: inline-flex;
-    min-height: 2.5rem;
+    min-height: 2.75rem;
     align-items: center;
     border-radius: var(--bw-radius);
     padding-inline: 0.75rem;
@@ -422,12 +434,12 @@
     line-height: 1.2;
   }
 
-	  @media (hover: hover) {
-	    .bw-hero-placeholder:hover {
-	      border-color: var(--bw-accent);
-	      box-shadow: 0 10px 20px oklch(13% 0.05 156 / 0.16);
-	      transform: translateY(-2px);
-	    }
+  @media (hover: hover) {
+    .bw-hero-placeholder:hover {
+      border-color: var(--bw-accent);
+      box-shadow: 0 10px 20px oklch(13% 0.05 156 / 0.16);
+      transform: translateY(-2px);
+    }
 
     .bw-hero-placeholder:hover .bw-hero-placeholder__action {
       color: var(--bw-ink);
@@ -542,8 +554,8 @@
 
   .bw-icon-button {
     display: inline-flex;
-    min-width: 2.5rem;
-    min-height: 2.5rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
     align-items: center;
     justify-content: center;
     border: 1px solid var(--bw-border);
@@ -565,6 +577,121 @@
     background: var(--bw-primary-soft);
     color: var(--bw-primary-dark);
     transform: translateY(-1px);
+  }
+
+  .bw-ad-mobile {
+    position: fixed;
+    inset-inline: 0;
+    bottom: 0;
+    z-index: 50;
+    border-top: 1px solid var(--bw-border-strong);
+    background: oklch(98.8% 0.012 112);
+    box-shadow: 0 -16px 38px oklch(16% 0.04 151 / 0.18);
+    opacity: 1;
+    transform: translateY(100%);
+    transition: transform 220ms var(--bw-ease);
+  }
+
+  .bw-ad-mobile__inner {
+    display: flex;
+    width: min(100% - 2rem, 72rem);
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-inline: auto;
+    padding-block: 0.75rem;
+  }
+
+  .bw-ad-mobile__link {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+  }
+
+  .bw-ad-desktop {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 50;
+    width: min(20rem, calc(100vw - 2rem));
+    border: 1px solid var(--bw-border-strong);
+    border-radius: var(--bw-radius);
+    background: oklch(98.8% 0.012 112);
+    background-clip: padding-box;
+    box-shadow: 0 24px 60px oklch(16% 0.04 151 / 0.26), 0 1px 0 oklch(100% 0.01 118) inset;
+    isolation: isolate;
+    opacity: 1;
+    padding: 1rem;
+    transform: translateY(0.5rem);
+    transition: transform 220ms var(--bw-ease);
+  }
+
+  .bw-ad--visible {
+    transform: translateY(0);
+  }
+
+  .bw-ad__logo {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--bw-border);
+    border-radius: var(--bw-radius);
+    background: oklch(99% 0.01 118);
+    transition: border-color 150ms var(--bw-ease), transform 150ms var(--bw-ease);
+  }
+
+  .bw-ad__logo:hover {
+    border-color: var(--bw-primary);
+    transform: translateY(-1px);
+  }
+
+  .bw-ad__logo--mobile {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .bw-ad__logo--desktop {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
+
+  .bw-ad__logo-image {
+    object-fit: contain;
+  }
+
+  .bw-ad__logo-image--mobile {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+
+  .bw-ad__logo-image--desktop {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .bw-ad__close-desktop {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    width: 2rem;
+    min-width: 2rem;
+    height: 2rem;
+    min-height: 2rem;
+  }
+
+  @media (max-width: 1023px) {
+    .bw-ad-desktop {
+      display: none;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .bw-ad-mobile {
+      display: none;
+    }
   }
 
   .bw-project-screenshot {
@@ -611,6 +738,44 @@
     }
   }
 
+  .bw-search-result {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    border-bottom: 1px solid var(--bw-border);
+    padding: 1rem;
+    color: var(--bw-ink);
+    text-decoration: none;
+    transition: background-color 150ms var(--bw-ease);
+  }
+
+  .bw-search-result:last-child {
+    border-bottom: 0;
+  }
+
+  .bw-search-result:hover,
+  .bw-search-result--active {
+    background: var(--bw-primary-soft);
+  }
+
+  .bw-search-result__title {
+    color: var(--bw-ink);
+    font-weight: 750;
+    line-height: 1.25;
+  }
+
+  .bw-search-result__description {
+    color: var(--bw-muted);
+    font-size: 0.875rem;
+    line-height: 1.35;
+  }
+
+  .bw-search-empty {
+    padding: 1rem;
+    color: var(--bw-muted);
+    font-size: 0.875rem;
+  }
+
   .bw-settings-section {
     display: grid;
     gap: 1.25rem;
@@ -648,7 +813,8 @@
     color: var(--bw-ink);
     font-size: 0.875rem;
     line-height: 1.25rem;
-    padding: 0.625rem 0.75rem;
+    min-height: 2.75rem;
+    padding: 0.7rem 0.75rem;
   }
 
   .bw-form-input::placeholder {
@@ -658,6 +824,25 @@
   .bw-form-input:focus {
     border-color: var(--bw-primary);
     box-shadow: 0 0 0 3px oklch(51% 0.15 151 / 0.18);
+  }
+
+  .bw-inline-form {
+    display: flex;
+    width: 100%;
+    max-width: 28rem;
+    align-items: stretch;
+  }
+
+  .bw-inline-form .bw-form-input {
+    margin-top: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
+
+  .bw-inline-form .bw-button {
+    flex-shrink: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
 
   .bw-form-checkbox {
@@ -687,6 +872,11 @@
     list-style: none;
   }
 
+  .bw-status-error {
+    color: var(--bw-danger);
+    font-weight: 750;
+  }
+
   .bw-prose {
     color: var(--bw-ink-soft);
   }
@@ -706,6 +896,24 @@
     border-top: 1px solid var(--bw-border);
     background: var(--bw-ink);
     color: oklch(91% 0.025 126);
+  }
+
+  .bw-footer-brand {
+    display: inline-flex;
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.75rem;
+    color: inherit;
+    font-weight: 850;
+    text-decoration: none;
+  }
+
+  .bw-footer-link {
+    display: flex;
+    min-height: 2.75rem;
+    align-items: center;
+    color: inherit;
+    text-decoration: none;
   }
 
   .bw-footer a:hover {
@@ -777,10 +985,54 @@
     min-width: 0;
   }
 
-  .btn-blue {
-    @apply inline-flex items-center px-4 py-2 font-semibold text-white bg-blue-500 rounded-lg shadow-md;
-    @apply hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75;
+  .bw-webring-fallback {
+    display: grid;
+    gap: 0.55rem;
   }
+
+  .bw-webring-fallback a {
+    display: inline-flex;
+    min-height: 3.25rem;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0.18rem;
+    border: 1px solid oklch(43% 0.05 150);
+    border-radius: var(--bw-radius);
+    background: oklch(17% 0.032 151);
+    color: oklch(93% 0.025 126);
+    padding: 0.7rem 0.78rem;
+    font-size: 0.86rem;
+    font-weight: 900;
+    line-height: 1.05;
+    text-decoration: none;
+    transition:
+      background-color 160ms var(--bw-ease),
+      border-color 160ms var(--bw-ease),
+      color 160ms var(--bw-ease),
+      transform 160ms var(--bw-ease);
+  }
+
+  .bw-webring-fallback a span + span {
+    color: oklch(70% 0.025 126);
+    font-size: 0.7rem;
+    font-weight: 750;
+    line-height: 1.1;
+  }
+
+  .bw-webring-fallback a:hover,
+  .bw-webring-fallback a:focus-visible {
+    border-color: oklch(76% 0.15 92);
+    background: oklch(23% 0.052 151);
+    color: oklch(97% 0.018 116);
+    transform: translateY(-1px);
+  }
+
+  .bw-webring-fallback a:hover span + span,
+  .bw-webring-fallback a:focus-visible span + span {
+    color: oklch(83% 0.07 92);
+  }
+
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/webpack/webpack.common.js
+++ b/frontend/webpack/webpack.common.js
@@ -32,7 +32,16 @@ module.exports = {
     new CleanWebpackPlugin(),
     new CopyWebpackPlugin({
       patterns: [
-        { from: Path.resolve(__dirname, "../vendors"), to: "vendors" },
+        {
+          from: Path.resolve(__dirname, "../vendors"),
+          to: "vendors",
+          globOptions: {
+            ignore: [
+              "**/images/sample.jpg",
+              "**/images/webpack.png",
+            ],
+          },
+        },
       ],
     }),
     new WebpackAssetsManifest({

--- a/frontend/webpack/webpack.config.prod.js
+++ b/frontend/webpack/webpack.config.prod.js
@@ -40,6 +40,14 @@ module.exports = merge(common, {
       chunkFilename: "css/[id].[contenthash].css",
     }),
   ].concat(sentryPluginEnabled ? [sentryWebpackPlugin(sentryPluginOptions)] : []),
+  performance: {
+    maxAssetSize: 244 * 1024,
+    maxEntrypointSize: 244 * 1024,
+    assetFilter: (assetFilename) => {
+      if (/\.map$/.test(assetFilename)) return false;
+      return !/^js\/sentry\.[a-f0-9]+\.chunk\.js$/.test(assetFilename);
+    },
+  },
   module: {
     rules: [
       {

--- a/newsletter/forms.py
+++ b/newsletter/forms.py
@@ -12,7 +12,7 @@ class NewsletterSignupForm(ModelForm):
             self.fields[fieldname].help_text = None
             self.fields[fieldname].widget.attrs.update(
                 {
-                    "class": "block appearance-none w-full bg-white border border-solid border-grey-light hover:border-grey px-2 py-2 rounded-l-lg shadow"
+                    "class": "block min-h-[2.75rem] w-full appearance-none rounded-lg border border-solid border-grey-light bg-white px-3 py-3 text-base shadow hover:border-grey"
                 }
             )
             self.fields[fieldname].widget.attrs["placeholder"] = "email@mail.com"

--- a/pages/forms.py
+++ b/pages/forms.py
@@ -12,19 +12,19 @@ class AddNftRequest(ModelForm):
         super(AddNftRequest, self).__init__(*args, **kwargs)
         self.fields["email"].widget.attrs.update(
             {
-                "class": "block w-full border-0 p-1 bg-gray-100 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-md",
+                "class": "bw-form-input text-base",
                 "placeholder": "test@example.com",
             }
         )
         self.fields["wallet_public_key"].widget.attrs.update(
             {
-                "class": "block w-full border-0 p-1 bg-gray-100 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-md",
+                "class": "bw-form-input text-base",
                 "placeholder": "0x123456789651bE2ad266e9ca6A9d50686B183e49",
             }
         )
         self.fields["date_requested"].widget.attrs.update(
             {
-                "class": "block w-full border-0 p-1 bg-gray-100 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-md",
+                "class": "bw-form-input text-base",
                 "placeholder": "2021-11-23",
             }
         )

--- a/projects/views.py
+++ b/projects/views.py
@@ -56,6 +56,7 @@ class ProjectListView(FilterView):
 
 
 class InactiveProjectListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
+    login_url = "account_login"
     model = Project
     template_name = "projects/all_inactive_projects.html"
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,19 @@
 module.exports = {
   content: [
     './templates/**/*.html',
+    './frontend/src/**/*.js',
   ],
-  // https://nexxai.dev/tell-purgecss-to-ignore-purging-all-tailwind-colours/
+  // Dynamic classes that come from template data rather than static markup.
   safelist: [
-    {pattern: /(bg|text)-(.*)-(.*)/},
-    {pattern: /(w)-(.*)/},
-    {pattern: /(h)-(.*)/},
+    'h-12',
+    'h-20',
+    'h-40',
+    'w-12',
+    'w-20',
+    'w-40',
+    {
+      pattern: /^(bg|text)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(100|800)$/,
+    },
   ],
   theme: {
     extend: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
     'w-20',
     'w-40',
     {
-      pattern: /^(bg|text)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(100|800)$/,
+      pattern: /^(bg|text)-(slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-(50|100|200|300|400|500|600|700|800|900)$/,
     },
   ],
   theme: {

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -10,12 +10,12 @@
     <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
         <div class="space-y-8 w-full max-w-md">
             <div>
-                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
+                <h1 class="mt-6 text-3xl font-black text-center text-[var(--bw-ink)]">
                     Sign in to your account
-                </h2>
-                <p class="mt-2 text-sm text-center text-gray-600">
+                </h1>
+                <p class="mt-2 text-sm text-center bw-muted">
                     Or
-                    <a href="{% url 'account_signup' %}" class="font-medium text-green-600 hover:text-green-500">
+                    <a href="{% url 'account_signup' %}" class="font-bold text-[var(--bw-primary-dark)] underline-offset-2 hover:underline">
                         sign up if you don't have one yet.
                     </a>
                 </p>
@@ -28,20 +28,20 @@
                     <div>
                         {{ form.login.errors | safe }}
                         <label for="username" class="sr-only">Username</label>
-                        {% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-t-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
+                        {% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative min-h-[2.75rem] px-3 py-2 w-full placeholder:text-[var(--bw-muted)] text-[var(--bw-ink)] bg-[var(--bw-surface)] rounded-none rounded-t-md border border-[var(--bw-border)] appearance-none focus:outline-none focus:ring-[var(--bw-primary)] focus:border-[var(--bw-primary)] focus:z-10 sm:text-sm" %}
                     </div>
                     <div>
                         {{ form.password.errors | safe }}
                         <label for="password" class="sr-only">Password</label>
-                        {% render_field form.password id="password" name="password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-b-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" placeholder="Confirm Password" %}
+                        {% render_field form.password id="password" name="password" type="password" autocomplete="current-password" required="True" class="block relative min-h-[2.75rem] px-3 py-2 w-full placeholder:text-[var(--bw-muted)] text-[var(--bw-ink)] bg-[var(--bw-surface)] rounded-none rounded-b-md border border-[var(--bw-border)] appearance-none focus:outline-none focus:ring-[var(--bw-primary)] focus:border-[var(--bw-primary)] focus:z-10 sm:text-sm" placeholder="Password" %}
                     </div>
                 </div>
                 <div>
                     <button type="submit"
-                            class="flex relative justify-center px-4 py-2 w-full text-sm font-medium text-white bg-green-600 rounded-md border border-transparent border-solid group hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
+                            class="bw-button bw-button-primary relative w-full group">
                         <span class="flex absolute inset-y-0 left-0 items-center pl-3">
                             <!-- Heroicon name: solid/lock-closed -->
-                            <svg class="w-5 h-5 text-green-500 group-hover:text-green-400"
+                            <svg class="w-5 h-5 text-[oklch(82%_0.08_145)] group-hover:text-[oklch(94%_0.04_145)]"
                                  xmlns="http://www.w3.org/2000/svg"
                                  viewBox="0 0 20 20"
                                  fill="currentColor"
@@ -69,7 +69,7 @@
                     {% if 'twitter' in available_social_providers %}
                     <div>
                         <a href="{% provider_login_url 'twitter' %}"
-                           class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-500 bg-white rounded-md border border-gray-300 border-solid shadow-sm hover:bg-gray-50">
+                           class="inline-flex min-h-[2.75rem] justify-center px-4 py-2 w-full text-sm font-medium text-[var(--bw-muted)] bg-[var(--bw-surface)] rounded-md border border-[var(--bw-border)] border-solid shadow-sm hover:bg-[var(--bw-surface-raised)]">
                             <span class="sr-only">Sign in with Twitter</span>
                             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                                 <path d="M6.29 18.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0020 3.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.073 4.073 0 01.8 7.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 010 16.407a11.616 11.616 0 006.29 1.84"/>
@@ -80,7 +80,7 @@
                     {% if 'github' in available_social_providers %}
                     <div>
                         <a href="{% provider_login_url 'github' %}"
-                           class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-500 bg-white rounded-md border border-gray-300 border-solid shadow-sm hover:bg-gray-50">
+                           class="inline-flex min-h-[2.75rem] justify-center px-4 py-2 w-full text-sm font-medium text-[var(--bw-muted)] bg-[var(--bw-surface)] rounded-md border border-[var(--bw-border)] border-solid shadow-sm hover:bg-[var(--bw-surface-raised)]">
                             <span class="sr-only">Sign in with GitHub</span>
                             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                                 <path fill-rule="evenodd"

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -7,54 +7,41 @@
 {% endblock meta %}
 
 {% block content %}
-    <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
-        <div class="space-y-8 w-full max-w-md">
-            <div>
-                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
-                    Create your account
-                </h2>
-            </div>
-            <form class="mt-8 space-y-6" method="post">
+    <section class="bw-section">
+      <div class="bw-container">
+        <div class="bw-surface mx-auto max-w-md p-5 sm:p-8">
+            <h1 class="bw-heading-md text-center">
+                Create your account
+            </h1>
+            <form class="mt-8 grid gap-5" method="post">
                 {% csrf_token %}
                 {{ form.non_field_errors | safe }}
                 <input type="hidden" name="remember" value="true" />
-                <div class="-space-y-px rounded-md shadow-sm">
+                <div class="grid gap-4">
                     <div>
                       {{ form.username.errors | safe }}
-                      <label for="username" class="sr-only">Username</label>
-                      {% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-t-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
+                      <label for="username" class="bw-form-label">Username</label>
+                      {% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="bw-form-input text-base" %}
                     </div>
                     <div>
                       {{ form.email.errors | safe }}
-                      <label for="email" class="sr-only">Username</label>
-                      {% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
+                      <label for="email" class="bw-form-label">Email</label>
+                      {% render_field form.email id="email" name="email" placeholder="you@example.com" type="email" autocomplete="email" required=True class="bw-form-input text-base" %}
                     </div>
                     <div>
                       {{ form.password1.errors | safe }}
-                      <label for="id_password1" class="sr-only">Password</label>
-                      {% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %}
+                      <label for="password1" class="bw-form-label">Password</label>
+                      {% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="new-password" required=True class="bw-form-input text-base" %}
                     </div>
                     <div>
                       {{ form.password2.errors | safe }}
-                      <label for="password2" class="sr-only">Password</label>
-                      {% render_field form.password2 id="password2" name="password2" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-b-md border border-gray-300 appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" placeholder="Confirm Password" %}
+                      <label for="password2" class="bw-form-label">Confirm password</label>
+                      {% render_field form.password2 id="password2" name="password2" type="password" autocomplete="new-password" required=True class="bw-form-input text-base" placeholder="Confirm password" %}
                     </div>
                 </div>
                 <div>
                     <button type="submit"
-                            class="flex relative justify-center px-4 py-2 w-full text-sm font-medium text-white bg-green-600 rounded-md border border-transparent border-solid group hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-                        <span class="flex absolute inset-y-0 left-0 items-center pl-3">
-                            <!-- Heroicon name: solid/lock-closed -->
-                            <svg class="w-5 h-5 text-green-500 group-hover:text-green-400"
-                                 xmlns="http://www.w3.org/2000/svg"
-                                 viewBox="0 0 20 20"
-                                 fill="currentColor"
-                                 aria-hidden="true">
-                                <path fill-rule="evenodd"
-                                      d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
-                                      clip-rule="evenodd"/>
-                            </svg>
-                        </span>
+                            class="bw-button bw-button-primary w-full">
                         Sign up
                     </button>
                 </div>
@@ -66,14 +53,14 @@
                         <div class="w-full border-t border-gray-300 border-solid"></div>
                     </div>
                     <div class="flex relative justify-center text-sm">
-                        <span class="px-2 text-gray-500 bg-white">Or continue with</span>
+                        <span class="bg-[var(--bw-surface)] px-2 bw-muted">Or continue with</span>
                     </div>
                 </div>
                 <div class="grid grid-cols-2 gap-3 mt-6">
                     {% if 'twitter' in available_social_providers %}
                     <div>
                         <a href="{% provider_login_url 'twitter' %}"
-                           class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-500 bg-white rounded-md border border-gray-300 border-solid shadow-sm hover:bg-gray-50">
+                           class="bw-button bw-button-secondary w-full">
                             <span class="sr-only">Sign in with Twitter</span>
                             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                                 <path d="M6.29 18.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0020 3.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.073 4.073 0 01.8 7.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 010 16.407a11.616 11.616 0 006.29 1.84"/>
@@ -84,7 +71,7 @@
                     {% if 'github' in available_social_providers %}
                     <div>
                         <a href="{% provider_login_url 'github' %}"
-                           class="inline-flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-500 bg-white rounded-md border border-gray-300 border-solid shadow-sm hover:bg-gray-50">
+                           class="bw-button bw-button-secondary w-full">
                             <span class="sr-only">Sign in with GitHub</span>
                             <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                                 <path fill-rule="evenodd"
@@ -98,5 +85,6 @@
             </div>
             {% endif %}
         </div>
-    </div>
+      </div>
+    </section>
 {% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,12 +14,12 @@
     {% endblock meta %}
 
     <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css" />
     {% stylesheet_pack 'hotwire' attrs='data-turbo-track="reload"' %}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js" defer></script>
-    <script defer data-domain="builtwithdjango.com" src="https://plausible-v2.cr.lvtd.dev/js/script.js"></script>
+    {% if app_environment == "prod" %}
+      <script defer data-domain="builtwithdjango.com" src="https://plausible-v2.cr.lvtd.dev/js/script.js"></script>
+    {% endif %}
     {% if sentry_browser_enabled %}
       {{ sentry_browser_config|json_script:"bwd-sentry-config" }}
     {% endif %}
@@ -234,7 +234,7 @@
     <header class="bw-site-header" x-data="{ isOn: false }">
       <nav class="bw-container flex min-h-[4.5rem] items-center justify-between gap-4" aria-label="Primary navigation">
         <a href="{% url 'home' %}" class="bw-brand">
-          <img src="{% static 'vendors/images/logo.png' %}" alt="Built with Django Logo" />
+          <img src="{% static 'vendors/images/logo.png' %}" width="220" height="234" alt="Built with Django Logo" />
           <span class="hidden text-lg sm:inline">Built with Django</span>
         </a>
 
@@ -243,11 +243,17 @@
           <a href="{% url 'blog' %}" class="bw-nav-link" data-analytics-event="nav clicked" data-analytics-nav-item="guides">Guides</a>
           <a href="{% url 'jobs' %}" class="bw-nav-link" data-analytics-event="nav clicked" data-analytics-nav-item="jobs">Jobs</a>
           <div data-controller="dropdown" class="relative">
-            <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" class="bw-nav-link" aria-expanded="false">
+            <button type="button"
+                    data-action="dropdown#toggle click@window->dropdown#hide"
+                    class="bw-nav-link"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-controls="resources-menu">
               Resources
               <i class="las la-angle-down ml-1 text-sm" aria-hidden="true"></i>
             </button>
             <div data-dropdown-target="menu"
+                 id="resources-menu"
                  data-transition-enter-active="transition ease-out duration-200"
                  data-transition-enter-from="opacity-0 translate-y-1"
                  data-transition-enter-to="opacity-100 translate-y-0"
@@ -274,11 +280,17 @@
             </div>
           </div>
           <div data-controller="dropdown" class="relative">
-            <button type="button" data-action="dropdown#toggle click@window->dropdown#hide" class="bw-nav-link" aria-expanded="false">
+            <button type="button"
+                    data-action="dropdown#toggle click@window->dropdown#hide"
+                    class="bw-nav-link"
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-controls="tools-menu">
               Tools
               <i class="las la-angle-down ml-1 text-sm" aria-hidden="true"></i>
             </button>
             <div data-dropdown-target="menu"
+                 id="tools-menu"
                  data-transition-enter-active="transition ease-out duration-200"
                  data-transition-enter-from="opacity-0 translate-y-1"
                  data-transition-enter-to="opacity-100 translate-y-0"
@@ -318,7 +330,8 @@
                       data-action="dropdown#toggle click@window->dropdown#hide"
                       class="inline-flex h-11 w-11 items-center justify-center overflow-hidden rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)]"
                       aria-expanded="false"
-                      aria-haspopup="true">
+                      aria-haspopup="true"
+                      aria-controls="user-menu">
                 <span class="sr-only">Open user menu</span>
                 {% include "components/profile-image.html" %}
               </button>
@@ -329,6 +342,7 @@
                    data-transition-leave-active="transition ease-in duration-75"
                    data-transition-leave-from="transform opacity-100 scale-100"
                    data-transition-leave-to="transform opacity-0 scale-95"
+                   id="user-menu"
                    class="bw-menu-panel hidden absolute right-0 z-20 mt-3 w-56 p-2"
                    role="menu">
                 <p class="px-3 py-2 text-sm font-bold bw-muted">{{ user.username }}</p>
@@ -410,8 +424,8 @@
     <footer class="bw-footer">
       <div class="bw-container grid gap-10 py-12 md:grid-cols-[1.2fr_0.8fr_0.8fr] lg:py-16">
         <div>
-          <a href="{% url 'home' %}" class="inline-flex items-center gap-3 font-black">
-            <img class="h-10 w-10" src="{% static 'vendors/images/logo.png' %}" alt="Built with Django Logo" />
+          <a href="{% url 'home' %}" class="bw-footer-brand">
+            <img class="h-10 w-10" src="{% static 'vendors/images/logo.png' %}" width="220" height="234" alt="Built with Django Logo" />
             <span>Built with Django</span>
           </a>
           <p class="mt-4 max-w-md text-sm leading-6 text-[oklch(82%_0.03_126)]">
@@ -424,20 +438,20 @@
         <div>
           <h2 class="text-sm font-black uppercase tracking-wider text-[oklch(94%_0.025_126)]">Explore</h2>
           <div class="mt-4 grid gap-3 text-sm">
-            <a href="{% url 'projects' %}">Projects</a>
-            <a href="{% url 'blog' %}">Guides</a>
-            <a href="{% url 'jobs' %}">Jobs</a>
-            <a href="{% url 'podcast_episodes' %}">Podcast</a>
+            <a href="{% url 'projects' %}" class="bw-footer-link">Projects</a>
+            <a href="{% url 'blog' %}" class="bw-footer-link">Guides</a>
+            <a href="{% url 'jobs' %}" class="bw-footer-link">Jobs</a>
+            <a href="{% url 'podcast_episodes' %}" class="bw-footer-link">Podcast</a>
           </div>
         </div>
         <div>
           <h2 class="text-sm font-black uppercase tracking-wider text-[oklch(94%_0.025_126)]">Build with us</h2>
           <div class="mt-4 grid gap-3 text-sm">
-            <a href="{% url 'submit_project' %}">Submit a project</a>
-            <a href="{% url 'post_job' %}">Post a job</a>
-            <a href="{% url 'advertize' %}">Advertise</a>
-            <a href="https://github.com/LVTD-LLC/builtwithdjango">GitHub</a>
-            <a href="https://x.com/rasulkireev">X</a>
+            <a href="{% url 'submit_project' %}" class="bw-footer-link">Submit a project</a>
+            <a href="{% url 'post_job' %}" class="bw-footer-link">Post a job</a>
+            <a href="{% url 'advertize' %}" class="bw-footer-link">Advertise</a>
+            <a href="https://github.com/LVTD-LLC/builtwithdjango" class="bw-footer-link">GitHub</a>
+            <a href="https://x.com/rasulkireev" class="bw-footer-link">X</a>
           </div>
         </div>
       </div>
@@ -449,11 +463,21 @@
             <p>Follow the ring to visit a previous, random, or next member site from the Django community.</p>
           </div>
           <div class="bw-webring-widget" role="navigation" aria-label="Django Webring navigation">
-            <webring-css site="https://builtwithdjango.com"></webring-css>
+            {% if app_environment == "prod" %}
+              <webring-css site="https://builtwithdjango.com"></webring-css>
+            {% else %}
+              <div class="bw-webring-fallback">
+                <a href="https://djangowebring.com/" target="_blank" rel="noopener">
+                  <span>Visit the ring</span>
+                  <span>Django Webring directory</span>
+                </a>
+              </div>
+            {% endif %}
           </div>
         </div>
-        <script src="https://djangowebring.com/static/webring.js" defer></script>
-        <script>
+        {% if app_environment == "prod" %}
+          <script src="https://djangowebring.com/static/webring.js" defer></script>
+          <script>
           function restyleDjangoWebring() {
             const host = document.querySelector('.bw-webring-widget webring-css');
             if (!host) return;
@@ -638,7 +662,8 @@
 
           document.addEventListener('DOMContentLoaded', restyleDjangoWebring);
           document.addEventListener('turbo:load', restyleDjangoWebring);
-        </script>
+          </script>
+        {% endif %}
       </div>
     </footer>
 

--- a/templates/blog/all_articles.html
+++ b/templates/blog/all_articles.html
@@ -8,13 +8,7 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero">
-  <div class="bw-container">
-    <p class="bw-kicker">Articles</p>
-    <h1 class="bw-heading-lg mt-3">Django notes from the community</h1>
-    <p class="bw-lede mt-5">Articles and collected context for people following the Django ecosystem.</p>
-  </div>
-</section>
+{% include "components/page-hero.html" with kicker="Articles" title="Django notes from the community" description="Articles and collected context for people following the Django ecosystem." %}
 
 <section class="pb-16">
   <div class="bw-container">

--- a/templates/blog/all_posts.html
+++ b/templates/blog/all_posts.html
@@ -8,13 +8,7 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero">
-  <div class="bw-container">
-    <p class="bw-kicker">Django guides</p>
-    <h1 class="bw-heading-lg mt-3">Learn Django by building</h1>
-    <p class="bw-lede mt-5">Tutorials and notes for developers who want practical patterns, not abstract framework tours.</p>
-  </div>
-</section>
+{% include "components/page-hero.html" with kicker="Django guides" title="Learn Django by building" description="Tutorials and notes for developers who want practical patterns, not abstract framework tours." %}
 
 <section class="pb-16">
   <div class="bw-container">

--- a/templates/components/bottom-right-corner-ad.html
+++ b/templates/components/bottom-right-corner-ad.html
@@ -1,11 +1,16 @@
-<aside id="ad-container-mobile" class="fixed inset-x-0 bottom-0 z-50 hidden border-t border-[var(--bw-border-strong)] shadow-lg lg:hidden">
-  <div class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3">
+<aside id="ad-container-mobile" class="bw-ad-mobile hidden lg:hidden" aria-label="Advertisement">
+  <div class="bw-ad-mobile__inner">
     <a target="_blank"
        rel="noopener"
        href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=mobile-bottom-ad-{% now "F-Y" %}'
-       class="flex min-w-0 items-center gap-3">
-      <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-[var(--bw-border)] bg-[oklch(99%_0.01_118)]">
-        <img src="https://djass.dev/static/vendors/images/logo.svg" alt="Djass" class="h-7 w-7 object-contain" />
+       class="bw-ad-mobile__link">
+      <span class="bw-ad__logo bw-ad__logo--mobile">
+        <img src="https://djass.dev/static/vendors/images/logo.svg"
+             alt="Djass"
+             width="28"
+             height="28"
+             decoding="async"
+             class="bw-ad__logo-image bw-ad__logo-image--mobile" />
       </span>
       <span class="min-w-0">
         <span class="block text-sm font-black text-[var(--bw-ink)]">Djass <span class="font-bold bw-muted">Ad</span></span>
@@ -18,14 +23,19 @@
   </div>
 </aside>
 
-<aside id="ad-container-desktop" class="fixed bottom-4 right-4 z-50 hidden w-80 rounded-lg border border-[var(--bw-border-strong)] p-4 shadow-lg">
+<aside id="ad-container-desktop" class="bw-ad-desktop hidden" aria-label="Advertisement">
   <p class="text-xs font-black uppercase tracking-wider bw-muted">Ad</p>
   <div class="mt-2 flex gap-3">
     <a target="_blank"
        rel="noopener"
        href='https://djass.dev/?ref=builtwithdjango.com&utm_source={{ request.get_host }}{{ request.path }}&utm_campaign=desktop-bottom-right-corner-ad-{% now "F-Y" %}'
-       class="flex h-14 w-14 shrink-0 items-center justify-center rounded-md border border-[var(--bw-border)] bg-[oklch(99%_0.01_118)]">
-      <img src="https://djass.dev/static/vendors/images/logo.svg" alt="Djass" class="h-10 w-10 object-contain" />
+       class="bw-ad__logo bw-ad__logo--desktop">
+      <img src="https://djass.dev/static/vendors/images/logo.svg"
+           alt="Djass"
+           width="40"
+           height="40"
+           decoding="async"
+           class="bw-ad__logo-image bw-ad__logo-image--desktop" />
     </a>
     <div class="min-w-0">
       <a target="_blank"
@@ -35,7 +45,7 @@
       <p class="mt-1 text-sm leading-5 bw-muted">Generate a production-ready Django SaaS starter repo.</p>
     </div>
   </div>
-  <button class="bw-icon-button close-ad absolute right-2 top-2 h-8 min-h-0 w-8 min-w-0" type="button" aria-label="Close ad">
+  <button class="bw-icon-button bw-ad__close-desktop close-ad" type="button" aria-label="Close ad">
     <i class="las la-times" aria-hidden="true"></i>
   </button>
 </aside>
@@ -45,21 +55,21 @@
     const adContainerMobile = document.getElementById('ad-container-mobile');
     const adContainerDesktop = document.getElementById('ad-container-desktop');
     const closeAdButtons = document.querySelectorAll('.close-ad');
+    const desktopMedia = window.matchMedia('(min-width: 1024px)');
+    const hiddenClass = 'hidden';
+    const visibleClass = 'bw-ad--visible';
+    let adIsVisible = false;
+    let adIsClosed = hasClosedCookie();
+    let revealFrame = 0;
+    let hideTimer = 0;
 
     if (!adContainerMobile || !adContainerDesktop) return;
 
-    function hideAd() {
-      if (window.innerWidth < 1024) {
-        adContainerMobile.style.transform = 'translateY(100%)';
-      } else {
-        adContainerDesktop.style.transform = 'translateY(8px)';
-      }
+    function hasClosedCookie() {
+      return document.cookie.split('; ').includes('adClosed=true');
+    }
 
-      window.setTimeout(() => {
-        adContainerMobile.style.display = 'none';
-        adContainerDesktop.style.display = 'none';
-      }, 220);
-
+    function setClosedCookie() {
       const date = new Date();
       date.setTime(date.getTime() + (24 * 60 * 60 * 1000));
       document.cookie = `adClosed=true; expires=${date.toUTCString()}; path=/`;
@@ -69,26 +79,75 @@
       return window.scrollY > Math.min(420, window.innerHeight * 0.6);
     }
 
-    function showAd() {
-      if (window.innerWidth < 1024) {
-        adContainerDesktop.style.display = 'none';
-        adContainerMobile.style.display = 'block';
-        window.setTimeout(() => {
-          adContainerMobile.style.transform = 'translateY(0)';
-        }, 80);
-      } else {
-        adContainerMobile.style.display = 'none';
-        adContainerDesktop.style.display = 'block';
-        window.setTimeout(() => {
-          adContainerDesktop.style.transform = 'translateY(0)';
-        }, 80);
+    function hideContainer(container) {
+      container.classList.remove(visibleClass);
+      container.classList.add(hiddenClass);
+    }
+
+    function showContainer(container) {
+      window.clearTimeout(hideTimer);
+      container.classList.remove(hiddenClass);
+
+      if (revealFrame) {
+        window.cancelAnimationFrame(revealFrame);
       }
+
+      revealFrame = window.requestAnimationFrame(() => {
+        container.classList.add(visibleClass);
+        revealFrame = 0;
+      });
+    }
+
+    function activeContainer() {
+      return desktopMedia.matches ? adContainerDesktop : adContainerMobile;
+    }
+
+    function syncVisibleAd() {
+      if (!adIsVisible) return;
+
+      const activeAd = activeContainer();
+      const inactiveAd = activeAd === adContainerDesktop ? adContainerMobile : adContainerDesktop;
+
+      hideContainer(inactiveAd);
+      showContainer(activeAd);
+    }
+
+    function showAd() {
+      if (adIsVisible || adIsClosed || hasClosedCookie()) return;
+
+      adIsVisible = true;
+      window.removeEventListener('scroll', maybeShowAd);
+      window.addEventListener('resize', syncVisibleAd);
+      syncVisibleAd();
     }
 
     function maybeShowAd() {
-      if (!document.cookie.includes('adClosed=true') && isPastIntro()) {
+      if (adIsClosed || hasClosedCookie()) {
+        adIsClosed = true;
+        window.removeEventListener('scroll', maybeShowAd);
+        return;
+      }
+
+      if (isPastIntro()) {
         showAd();
       }
+    }
+
+    function hideAd() {
+      adIsClosed = true;
+      adIsVisible = false;
+      window.removeEventListener('scroll', maybeShowAd);
+      window.removeEventListener('resize', syncVisibleAd);
+      window.cancelAnimationFrame(revealFrame);
+      setClosedCookie();
+
+      adContainerMobile.classList.remove(visibleClass);
+      adContainerDesktop.classList.remove(visibleClass);
+
+      hideTimer = window.setTimeout(() => {
+        adContainerMobile.classList.add(hiddenClass);
+        adContainerDesktop.classList.add(hiddenClass);
+      }, 220);
     }
 
     closeAdButtons.forEach((button) => {
@@ -97,34 +156,8 @@
 
     maybeShowAd();
 
-    window.addEventListener('scroll', maybeShowAd, { passive: true });
-
-    window.addEventListener('resize', () => {
-      if (!document.cookie.includes('adClosed=true') && isPastIntro()) {
-        showAd();
-      }
-    });
+    if (!adIsVisible && !adIsClosed) {
+      window.addEventListener('scroll', maybeShowAd, { passive: true });
+    }
   });
 </script>
-
-<style>
-  #ad-container-mobile {
-    background: oklch(98.8% 0.012 112);
-    background-color: oklch(98.8% 0.012 112);
-    opacity: 1;
-    transform: translateY(100%);
-    transition: transform 220ms var(--bw-ease);
-  }
-
-  #ad-container-desktop {
-    isolation: isolate;
-    background: oklch(98.8% 0.012 112);
-    background-color: oklch(98.8% 0.012 112);
-    background-clip: padding-box;
-    opacity: 1;
-    backdrop-filter: none;
-    box-shadow: 0 24px 60px oklch(16% 0.04 151 / 0.26), 0 1px 0 oklch(100% 0.01 118) inset;
-    transform: translateY(8px);
-    transition: transform 220ms var(--bw-ease);
-  }
-</style>

--- a/templates/components/modal-newsletter.html
+++ b/templates/components/modal-newsletter.html
@@ -59,20 +59,20 @@
                </div>
            </div>
        </div>
-	       <form class="mt-5 w-full sm:ml-4 sm:mt-4"
-	             action="{% url 'newsletter_home' %}"
-	             method="post"
-	             enctype="multipart/form-data">
-	           {% csrf_token %} {{ newsletter_form.non_field_errors }}
-	           <label for="modal-newsletter-email" class="sr-only">Email address</label>
-	           <div class="bw-inline-form">
-	               <span class="min-w-0 flex-1">
-	                   {% render_field newsletter_form.user_email id="modal-newsletter-email" class="bw-form-input" type="email" autocomplete="email" placeholder="you@example.com" %}
-	               </span>
-	               <button class="bw-button bw-button-primary"
-	                       type="submit">
-	                   Submit
-	               </button>
+       <form class="mt-5 w-full sm:ml-4 sm:mt-4"
+             action="{% url 'newsletter_home' %}"
+             method="post"
+             enctype="multipart/form-data">
+           {% csrf_token %} {{ newsletter_form.non_field_errors }}
+           <label for="modal-newsletter-email" class="sr-only">Email address</label>
+           <div class="bw-inline-form">
+               <span class="min-w-0 flex-1">
+                   {% render_field newsletter_form.user_email id="modal-newsletter-email" class="bw-form-input" type="email" autocomplete="email" placeholder="you@example.com" %}
+               </span>
+               <button class="bw-button bw-button-primary"
+                       type="submit">
+                   Submit
+               </button>
            </div>
        </form>
    </div>

--- a/templates/components/modal-newsletter.html
+++ b/templates/components/modal-newsletter.html
@@ -1,3 +1,5 @@
+{% load widget_tweaks %}
+
 <div data-turbo-cache="false"
       data-exit-intent-target="modal"
       class="fixed inset-0 z-10 hidden overflow-y-auto"
@@ -25,11 +27,10 @@
         data-transition-leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         class="inline-block px-4 pt-5 pb-4 overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
        <div class="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
-           <button data-action="click->
-               exit-intent#closeModal"
+           <button data-action="click->exit-intent#closeModal"
                data-exit-intent-target="closeButton"
                type="button"
-               class="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+               class="inline-flex h-11 w-11 items-center justify-center rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                >
                <span class="sr-only">Close</span>
                <!-- Heroicon name: outline/x -->
@@ -58,21 +59,20 @@
                </div>
            </div>
        </div>
-       <form class="flex flex-row items-center mt-5 sm:ml-4 sm:mt-4"
-             action="{% url 'newsletter_home' %}"
-             method="post"
-             enctype="multipart/form-data">
-           {% csrf_token %} {{ newsletter_form.non_field_errors }}
-           <div class="flex flex-row items-center">
-               <div class="flex flex-col">
-                   <div class="flex flex-row item-center">
-                       <span class="rounded-l-lg">{{ newsletter_form.user_email }}</span>
-                       <button class="px-4 py-2 font-bold text-white bg-green-700 rounded-r-lg shadow hover:bg-green-300"
-                               type="submit">
-                           Submit
-                       </button>
-                   </div>
-               </div>
+	       <form class="mt-5 w-full sm:ml-4 sm:mt-4"
+	             action="{% url 'newsletter_home' %}"
+	             method="post"
+	             enctype="multipart/form-data">
+	           {% csrf_token %} {{ newsletter_form.non_field_errors }}
+	           <label for="modal-newsletter-email" class="sr-only">Email address</label>
+	           <div class="bw-inline-form">
+	               <span class="min-w-0 flex-1">
+	                   {% render_field newsletter_form.user_email id="modal-newsletter-email" class="bw-form-input" type="email" autocomplete="email" placeholder="you@example.com" %}
+	               </span>
+	               <button class="bw-button bw-button-primary"
+	                       type="submit">
+	                   Submit
+	               </button>
            </div>
        </form>
    </div>

--- a/templates/components/page-hero.html
+++ b/templates/components/page-hero.html
@@ -1,0 +1,18 @@
+<section class="bw-page-hero{% if section_class %} {{ section_class }}{% endif %}">
+  <div class="{% firstof container_class 'bw-container' %}{% if cta_url and cta_label %} grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end{% endif %}">
+    <div{% if content_class %} class="{{ content_class }}"{% endif %}>
+      {% if kicker %}
+        <p class="bw-kicker">{{ kicker }}</p>
+      {% endif %}
+      {% if title %}
+        <h1 class="{% firstof heading_class 'bw-heading-lg mt-3' %}">{{ title }}</h1>
+      {% endif %}
+      {% if description %}
+        <p class="{% firstof description_class 'bw-lede mt-5' %}">{{ description }}</p>
+      {% endif %}
+    </div>
+    {% if cta_url and cta_label %}
+      <a href="{{ cta_url }}" class="{% firstof cta_class 'bw-button bw-button-accent' %}">{{ cta_label }}</a>
+    {% endif %}
+  </div>
+</section>

--- a/templates/developers/all_developers.html
+++ b/templates/developers/all_developers.html
@@ -7,18 +7,8 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero">
-  <div class="bw-container grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
-    <div>
-      <p class="bw-kicker">Developer directory</p>
-      <h1 class="bw-heading-lg mt-3">Hire Django people</h1>
-      <p class="bw-lede mt-5">
-        A community directory for developers who know Django and teams looking for practical web builders.
-      </p>
-    </div>
-    <a href="{% url 'update-profile' %}" class="bw-button bw-button-accent">Create your profile</a>
-  </div>
-</section>
+{% url 'update-profile' as update_profile_url %}
+{% include "components/page-hero.html" with kicker="Developer directory" title="Hire Django people" description="A community directory for developers who know Django and teams looking for practical web builders." cta_url=update_profile_url cta_label="Create your profile" %}
 
 <section class="pb-16">
   <div class="bw-container">

--- a/templates/jobs/all_jobs.html
+++ b/templates/jobs/all_jobs.html
@@ -8,18 +8,8 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero">
-  <div class="bw-container grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
-    <div>
-      <p class="bw-kicker">Django job board</p>
-      <h1 class="bw-heading-lg mt-3">Find teams building with Django</h1>
-      <p class="bw-lede mt-5">
-        Jobs from teams that care about Django experience, practical web development, and shipping real products.
-      </p>
-    </div>
-    <a href="{% url 'post_job' %}" class="bw-button bw-button-accent">Post a job</a>
-  </div>
-</section>
+{% url 'post_job' as post_job_url %}
+{% include "components/page-hero.html" with kicker="Django job board" title="Find teams building with Django" description="Jobs from teams that care about Django experience, practical web development, and shipping real products." cta_url=post_job_url cta_label="Post a job" %}
 
 <section class="pb-16">
   <div class="bw-container">

--- a/templates/jobs/post-job.html
+++ b/templates/jobs/post-job.html
@@ -7,13 +7,7 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero pb-10">
-  <div class="bw-container">
-    <p class="bw-kicker">Reach Django builders</p>
-    <h1 class="bw-heading-lg mt-3">Post a Django job</h1>
-    <p class="bw-lede mt-5">Share the core role details. After submitting, you'll be taken to a payment page for an optional sponsored post. You can skip sponsorship; your job will still be added to the job board.</p>
-  </div>
-</section>
+{% include "components/page-hero.html" with section_class="pb-10" kicker="Reach Django builders" title="Post a Django job" description="Share the core role details. After submitting, you'll be taken to a payment page for an optional sponsored post. You can skip sponsorship; your job will still be added to the job board." %}
 
 <section class="pb-16">
   <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,42rem)_1fr]">
@@ -23,35 +17,35 @@
         {{ form.non_field_errors }}
         <div>
           {{ form.title.errors }}
-          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.title.id_for_label }}">Role title</label>
-          {% render_field form.title class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="Senior Django Engineer" %}
+          <label class="bw-form-label" for="{{ form.title.id_for_label }}">Role title</label>
+          {% render_field form.title class="bw-form-input text-base" placeholder="Senior Django Engineer" %}
         </div>
         <div>
           {{ form.company_name.errors }}
-          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.company_name.id_for_label }}">Company name</label>
-          {% render_field form.company_name class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="Acme Studio" %}
+          <label class="bw-form-label" for="{{ form.company_name.id_for_label }}">Company name</label>
+          {% render_field form.company_name class="bw-form-input text-base" placeholder="Acme Studio" %}
         </div>
         <div>
           {{ form.listing_url.errors }}
-          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.listing_url.id_for_label }}">Job listing URL</label>
-          {% render_field form.listing_url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://example.com/jobs/django-engineer" %}
+          <label class="bw-form-label" for="{{ form.listing_url.id_for_label }}">Job listing URL</label>
+          {% render_field form.listing_url class="bw-form-input text-base" placeholder="https://example.com/jobs/django-engineer" %}
         </div>
         <div>
           {{ form.email.errors }}
-          <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.email.id_for_label }}">Your email</label>
-          {% render_field form.email class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="hiring@example.com" %}
+          <label class="bw-form-label" for="{{ form.email.id_for_label }}">Your email</label>
+          {% render_field form.email class="bw-form-input text-base" placeholder="hiring@example.com" %}
           <p class="mt-2 text-sm bw-muted">Only used to contact you about this listing.</p>
         </div>
         <div class="grid gap-5 sm:grid-cols-2">
           <div>
             {{ form.min_yearly_salary.errors }}
-            <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.min_yearly_salary.id_for_label }}">Min salary, USD</label>
-            {% render_field form.min_yearly_salary class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="120000" %}
+            <label class="bw-form-label" for="{{ form.min_yearly_salary.id_for_label }}">Min salary, USD</label>
+            {% render_field form.min_yearly_salary class="bw-form-input text-base" placeholder="120000" %}
           </div>
           <div>
             {{ form.max_yearly_salary.errors }}
-            <label class="block text-sm font-black text-[var(--bw-ink)]" for="{{ form.max_yearly_salary.id_for_label }}">Max salary, USD</label>
-            {% render_field form.max_yearly_salary class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="180000" %}
+            <label class="bw-form-label" for="{{ form.max_yearly_salary.id_for_label }}">Max salary, USD</label>
+            {% render_field form.max_yearly_salary class="bw-form-input text-base" placeholder="180000" %}
           </div>
         </div>
         <button data-action="click->loading#load" data-loading-target="button" class="bw-button bw-button-primary justify-self-start" type="submit">

--- a/templates/makers/all_makers.html
+++ b/templates/makers/all_makers.html
@@ -1,35 +1,33 @@
 {% extends "base.html" %}
 {% load static %}
+{% load widget_tweaks %}
 {% block meta %}
     {% include "components/seo_meta.html" with title="Django Makers | Built with Django" description="Meet the makers behind projects built with Django." canonical_path="/makers/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
-    <div class="overflow-hidden my-4 bg-white rounded-lg shadow">
-        <div class="px-4 py-5 sm:p-6">
-            <h1 class="text-3xl font-semibold text-gray-800">
-                Django Makers
-            </h1>
-            <p class="mb-5 text-2xl text-gray-600">
-                Subscribe to know about the coolest Django makers out there.
-            </p>
-            <form class="flex flex-row items-center"
-                  action="{% url 'newsletter_home' %}"
-                  method="post"
-                  enctype="multipart/form-data">
-                {% csrf_token %} {{ newsletter_form.non_field_errors }}
-                <div class="flex flex-row items-center">
-                    <div class="flex flex-col">
-                        <div class="flex flex-row item-center">
-                            <span class="rounded-l-lg">{{ newsletter_form.user_email }}</span>
-                            <button class="px-4 py-2 font-bold text-white bg-green-700 rounded-r-lg shadow hover:bg-green-300"
-                                    type="submit">
-                                Submit
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </form>
-        </div>
+    <div class="bw-surface mx-auto my-4 p-4 sm:p-6">
+        <h1 class="bw-heading-md">
+            Django Makers
+        </h1>
+        <p class="mt-2 max-w-2xl text-xl leading-8 bw-muted">
+            Subscribe to know about the coolest Django makers out there.
+        </p>
+        <form class="w-full"
+              action="{% url 'newsletter_home' %}"
+              method="post"
+              enctype="multipart/form-data">
+            {% csrf_token %} {{ newsletter_form.non_field_errors }}
+            <label for="makers-newsletter-email" class="sr-only">Email address</label>
+            <div class="bw-inline-form mt-5">
+                <span class="min-w-0 flex-1">
+                    {% render_field newsletter_form.user_email id="makers-newsletter-email" class="bw-form-input" type="email" autocomplete="email" placeholder="you@example.com" %}
+                </span>
+                <button class="bw-button bw-button-primary"
+                        type="submit">
+                    Submit
+                </button>
+            </div>
+        </form>
     </div>
     {% if messages %}
         <div class="p-4 my-4 bg-green-50 rounded-md border border-green-500 border-solid">
@@ -139,6 +137,16 @@
                     </a>
                 </div>
             {% endif %}
+        {% empty %}
+            <div class="bw-surface col-span-full p-6 text-center">
+                <h2 class="text-xl font-black text-[var(--bw-ink)]">No makers yet</h2>
+                <p class="mx-auto mt-2 max-w-md text-base leading-7 bw-muted">
+                    Published projects with linked makers will appear here once the directory has enough data.
+                </p>
+                <a class="bw-button bw-button-secondary mt-5" href="{% url 'projects' %}">
+                    Browse projects
+                </a>
+            </div>
         {% endfor %}
     </div>
 {% endblock content %}

--- a/templates/newsletter/email-form.html
+++ b/templates/newsletter/email-form.html
@@ -1,24 +1,32 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
 {% block meta %}
     {% include "components/seo_meta.html" with title="Built with Django Newsletter" description="Get new Django projects, guides, jobs, and podcast episodes by email." canonical_path="/newsletter/" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
-    <div class="w-auto mx-auto mt-10 lg:w-1/3">
-        <div class="p-8 mb-6 bg-white border-t-8 border-green-500 rounded-lg shadow-lg">
+    <section class="bw-section">
+      <div class="bw-container">
+        <div class="bw-surface mx-auto max-w-xl p-5 sm:p-8">
+            <p class="bw-kicker">Newsletter</p>
+            <h1 class="bw-heading-md mt-3">Get useful Django updates by email</h1>
+            <p class="mt-4 text-base leading-7 bw-muted">
+                New projects, guides, jobs, and community notes for people building with Django.
+            </p>
             <form method="post"
+                  class="mt-6 grid gap-4"
                   enctype="multipart/form-data"
                   data-analytics-source="newsletter page">
                 {% csrf_token %}
                 <input type="hidden" name="source" value="newsletter page" />
                 {{ form.non_field_errors }}
-                <div class="mb-4">
+                <div>
                     {{ form.user_email.errors }}
-                    <label class="block mb-2 font-bold text-gray-700" for="{{ form.user_email.id_for_label }}">
+                    <label class="bw-form-label" for="{{ form.user_email.id_for_label }}">
                         Email
                     </label>
-                    {{ form.user_email }}
+                    {% render_field form.user_email class="bw-form-input text-base" type="email" autocomplete="email" placeholder="you@example.com" %}
                 </div>
-                <button class="px-4 py-2 font-bold text-white bg-green-500 rounded hover:bg-green-300"
+                <button class="bw-button bw-button-primary justify-self-start"
                         type="submit"
                         data-analytics-event="newsletter submit clicked"
                         data-analytics-source="newsletter page">
@@ -26,5 +34,6 @@
                 </button>
             </form>
         </div>
-    </div>
+      </div>
+    </section>
 {% endblock content %}

--- a/templates/newsletter/sucessfull-email-submit.html
+++ b/templates/newsletter/sucessfull-email-submit.html
@@ -3,15 +3,20 @@
     {% include "components/seo_meta.html" with title="Newsletter Signup Complete | Built with Django" description="Thanks for signing up for the Built with Django newsletter." canonical_path="/newsletter/email-signup-thanks/" robots="noindex,nofollow" twitter_card="summary" image_alt="Built with Django logo" %}
 {% endblock meta %}
 {% block content %}
-    <div class="mx-auto mb-10 text-center">
-        <h1 class="text-4xl">Thanks for signing up!</h1>
-        <h2 class="text-2xl">
-            We will send you a rare email whenever we have a couple of new projects!
-        </h2>
-    </div>
-    <div class="mx-auto my-4 mb-10 text-center">
-        <a class="px-4 py-2 font-bold text-white bg-green-500 rounded hover:bg-green-700" href="{% url 'home' %}">
-            Back to Home Page
-        </a>
-    </div>
+    <section class="bw-section">
+      <div class="bw-container">
+        <div class="bw-surface mx-auto max-w-xl p-8 text-center">
+            <span class="bw-menu-icon mx-auto" aria-hidden="true">
+              <i class="las la-check"></i>
+            </span>
+            <h1 class="mt-5 text-3xl font-black leading-tight text-[var(--bw-ink)]">Thanks for signing up!</h1>
+            <p class="mx-auto mt-3 max-w-md text-base leading-7 bw-muted">
+                We will send a rare email whenever there are new Django projects worth seeing.
+            </p>
+            <a class="bw-button bw-button-primary mt-6" href="{% url 'home' %}">
+                Back to home
+            </a>
+        </div>
+      </div>
+    </section>
 {% endblock content %}

--- a/templates/pages/advertize.html
+++ b/templates/pages/advertize.html
@@ -15,7 +15,7 @@
   <section class="isolate overflow-hidden relative px-6 lg:px-8">
     <h2>Testimonials</h2>
     <div class="px-6 mx-auto max-w-2xl rounded-lg border border-gray-100 lg:max-w-4xl">
-      <img class="mx-auto h-12" src="{% static 'vendors/images/hovercode.png' %}" alt="Hovercode Logo">
+      <img class="mx-auto h-12" src="{% static 'vendors/images/hovercode.png' %}" width="128" height="128" alt="Hovercode Logo" decoding="async">
       <figure class="mt-10">
         <blockquote class="font-semibold text-center text-gray-900 text-xl/8 sm:text-2xl/9">
           <p>
@@ -26,7 +26,7 @@
           </p>
         </blockquote>
         <figcaption class="mt-10">
-          <img class="mx-auto w-16 rounded-full size-10" src="{% static 'vendors/images/ramy.jpg' %}" alt="Ramy Khuffash">
+          <img class="mx-auto h-16 w-16 rounded-full" src="{% static 'vendors/images/ramy.jpg' %}" width="400" height="400" alt="Ramy Khuffash" loading="lazy" decoding="async">
           <div class="flex justify-center items-center mt-4 space-x-3 text-base">
             <div class="font-semibold text-gray-900">Ramy Khuffash</div>
             <svg viewBox="0 0 2 2" width="3" height="3" aria-hidden="true" class="fill-gray-900">
@@ -43,24 +43,24 @@
 
   <h2>1. Highlighted product</h2>
   <p>Your site will be featured on the <a href="{% url 'home' %}">homepage</a> and on the <a href="{% url 'projects' %}">projects list</a>, which combined 2k - 2.5k unique users per month (images below). Since I just started and not entirely sure what this traffic is worth, I'm offering a whole month for $100.</p>
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.26.41.png' %}" alt="Highlighted product example 1">
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.26.05.png' %}" alt="Highlighted product example 2">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.26.41.png' %}" width="1292" height="863" alt="Highlighted product example 1" loading="lazy" decoding="async">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.26.05.png' %}" width="1227" height="874" alt="Highlighted product example 2" loading="lazy" decoding="async">
 
   <h2>2. Ad on the bottom right of the screen</h2>
   <p>This is displayed on every single page for every single visit. So you will be getting all the eyes that are coming from the site ~10K page views per month. I'm selling this ad spot for $200 per month (below are images for how it looks on desktop and mobile).</p>
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.31.35.png' %}" alt="Ad on desktop">
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.32.49.png' %}" alt="Ad on mobile">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.31.35.png' %}" width="2185" height="1278" alt="Ad on desktop" loading="lazy" decoding="async">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 10.32.49.png' %}" width="369" height="663" alt="Ad on mobile" loading="lazy" decoding="async">
 
   <h2>3. Sponsor block in the newsletter</h2>
   <p>~2000 subscribers and the open rate is always >50%, but close to 65% most of the time. I send 4 newsletters a month with 50 clicks on average. This will be $200 for 4 newsletter issues.</p>
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.53.00.png' %}" alt="Newsletter sponsor block example 1">
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.51.36.png' %}" alt="Newsletter sponsor block example 2">
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.51.59.png' %}" alt="Newsletter sponsor block example 3">
+  <img class="mx-auto my-3 max-h-[36rem] w-auto max-w-full rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.53.00.png' %}" width="523" height="1111" alt="Newsletter sponsor block example 1" loading="lazy" decoding="async">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.51.36.png' %}" width="763" height="423" alt="Newsletter sponsor block example 2" loading="lazy" decoding="async">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.51.59.png' %}" width="758" height="419" alt="Newsletter sponsor block example 3" loading="lazy" decoding="async">
 
   <h2>4. Sponsored Job Posting</h2>
   <p>This is perfect if you are hiring for Django Engineers. Your post will be first and highlighted on the <a href="{% url 'jobs' %}">Job Board</a> and on <a href="https://newsletter.builtwithdjango.com">the newsletter</a>. This will cost $200 for a month (4 newsletter issues).</p>
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/image.png' %}" alt="Sponsored Job Posting example 1">
-  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.57.45.png' %}" alt="Sponsored Job Posting example 2">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/image.png' %}" width="1283" height="764" alt="Sponsored Job Posting example 1" loading="lazy" decoding="async">
+  <img class="my-1 rounded border border-gray-200" src="{% static 'vendors/images/CleanShot 2024-09-19 at 11.57.45.png' %}" width="649" height="232" alt="Sponsored Job Posting example 2" loading="lazy" decoding="async">
 </article>
 
 {% endblock content %}

--- a/templates/pages/home.html
+++ b/templates/pages/home.html
@@ -57,7 +57,7 @@
         <p class="bw-kicker">Guides</p>
         <h2 class="bw-heading-md mt-3">Learn by building</h2>
       </div>
-      <a href="{% url 'blog' %}" class="hidden font-bold text-[var(--bw-primary-dark)] md:inline-flex">All guides</a>
+      <a href="{% url 'blog' %}" class="hidden min-h-[2.75rem] items-center rounded-md px-3 font-bold text-[var(--bw-primary-dark)] hover:bg-[var(--bw-primary-soft)] md:inline-flex">All guides</a>
     </div>
     <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
       {% for guide in guides %}

--- a/templates/pages/request-nft.html
+++ b/templates/pages/request-nft.html
@@ -5,137 +5,133 @@
     {% include "components/seo_meta.html" with title="Cistercian Date Club Request" description="Request a free NFT for the Cistercian Dates Club." canonical_path="/request-nft/" image=nft_banner robots="noindex,follow" image_alt="Cistercian Date Club banner" %}
 {% endblock meta %}
 {% block content %}
-    <div class="my-6">
+    {% include "components/page-hero.html" with section_class="pb-10" kicker="Cistercian Date Club" title="Request a Cistercian Date NFT" description="Submit one email, one wallet, and one date. If the date is available, you will receive a confirmation email before the transfer." %}
+
+    <section class="pb-16">
+      <div class="bw-container grid gap-8 lg:grid-cols-[minmax(0,38rem)_1fr]">
+        <div class="grid gap-6">
         {% if messages %}
-            <div class="p-4 my-4 border border-green-500 border-solid rounded-md bg-green-50">
-                <div class="flex">
-                    <div class="flex-shrink-0">
-                        <!-- Heroicon name: solid/check-circle -->
-                        <svg class="w-5 h-5 text-green-400"
-                             xmlns="http://www.w3.org/2000/svg"
-                             viewBox="0 0 20 20"
-                             fill="currentColor"
-                             aria-hidden="true">
-                            <path fill-rule="evenodd"
-                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-                                  clip-rule="evenodd"/>
-                        </svg>
-                    </div>
-                    <div class="ml-3">
-                        <div class="text-sm text-green-700">
-                            {% for message in messages %}
-                                <p>
-                                    {{ message }}
-                                </p>
-                            {% endfor %}
-                        </div>
-                    </div>
-                </div>
+          <div class="rounded-md border border-[var(--bw-border-strong)] bg-[var(--bw-accent-soft)] p-4" role="status" aria-live="polite">
+            <div class="flex gap-3">
+              <span class="bw-menu-icon h-8 w-8 text-base" aria-hidden="true">
+                <i class="las la-check"></i>
+              </span>
+              <div class="grid gap-1 text-sm font-bold text-[var(--bw-ink)]">
+                {% for message in messages %}
+                  <p>{{ message }}</p>
+                {% endfor %}
+              </div>
             </div>
+          </div>
         {% endif %}
-        <div class="mb-8 prose lg:prose-lg">
-            <h2>Cistercian Dates Club</h2>
+
+        <form method="post" class="bw-surface grid gap-5 p-5 sm:p-8" enctype="multipart/form-data">
+          {% csrf_token %}
+          {% if form.non_field_errors %}
+            <div class="bw-field-error">{{ form.non_field_errors }}</div>
+          {% endif %}
+          <div>
+            <label for="{{ form.email.id_for_label }}" class="bw-form-label">Email</label>
+            {{ form.email }}
+            {% if form.email.errors %}
+              <div class="bw-field-error">{{ form.email.errors }}</div>
+            {% endif %}
+          </div>
+          <div>
+            <label for="{{ form.wallet_public_key.id_for_label }}" class="bw-form-label">Wallet address, public key</label>
+            {{ form.wallet_public_key }}
+            {% if form.wallet_public_key.errors %}
+              <div class="bw-field-error">{{ form.wallet_public_key.errors }}</div>
+            {% endif %}
+          </div>
+          <div>
+            <label for="{{ form.date_requested.id_for_label }}" class="bw-form-label">Date you would like</label>
+            {{ form.date_requested }}
+            {% if form.date_requested.errors %}
+              <div class="bw-field-error">{{ form.date_requested.errors }}</div>
+            {% endif %}
+          </div>
+          <button type="submit" class="bw-button bw-button-primary justify-self-start">
+            Submit request
+          </button>
+        </form>
+        </div>
+
+        <aside class="bw-surface self-start p-5">
+          <h2 class="text-2xl font-black text-[var(--bw-ink)]">How requests work</h2>
+          <div class="bw-prose prose mt-4 max-w-none">
             <p>
                 This is a request form for the
-                <a href="https://opensea.io/collection/cistercian-date-club">
+                <a href="https://opensea.io/collection/cistercian-date-club" target="_blank" rel="noopener">
                     Cistercian Date NFT project
-                </a>
-                .
+                </a>.
             </p>
             <p>
-                For a limited time, we are giving away those NFTs for free. In order to receive one please submit a request.
+                For a limited time, these NFTs are free. To receive one, submit a request.
             </p>
             <p>
-                Please note, you can only request one NFT per email, per wallet, per date. That means that:
+                You can only request one NFT per email, per wallet, and per date:
             </p>
             <ul>
                 <li>
-                    one wallet can't receive two NFTs
+                    One wallet cannot receive two NFTs.
                 </li>
                 <li>
-                    one email can't receive two NFTs
+                    One email cannot receive two NFTs.
                 </li>
                 <li>
-                    if someone requested date that you want, you can't get that NFT
+                    If someone already requested the date you want, that NFT is no longer available.
                 </li>
             </ul>
             <p>
-                Some of the dates don't exist yet. Once they are created I will send them to the wallet you have specified.
+                Some dates do not exist yet. Once they are created, they will be sent to the wallet you specify.
             </p>
             <p>
-                Finally, I am asking for an email to notify you of the successfull transfer (I will ask you to confirm it) :)
+                Your email is used to confirm the request and notify you when the transfer succeeds.
             </p>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section class="pb-16">
+      <div class="bw-container">
+        <div class="mb-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p class="bw-kicker">Requested dates</p>
+            <h2 class="bw-heading-md mt-2">Dates already requested</h2>
+          </div>
+          <p class="text-sm font-bold bw-muted">{{ dates_requested|length }} total</p>
         </div>
-        <form method="post" class="max-w-lg" enctype="multipart/form-data">
-            {% csrf_token %}
-            {{ form.non_field_errors }}
-            <div class="flex flex-col mb-4 space-y-4">
-                <span class="hidden focus:ring-0">
-                    Making sure focus ring classes actually get created
-                </span>
-                <div class="relative px-3 py-2 border border-gray-300 border-solid rounded-md shadow-sm focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
-                    {{ form.email.errors }}
-                    <label for="{{ form.email.id_for_label }}"
-                           class="absolute inline-block px-1 -mt-1 font-medium text-gray-900 bg-gray-100 text-md -top-2 left-2">
-                        Email
-                    </label>
-                    {{ form.email }}
-                </div>
-                <div class="relative px-3 py-2 border border-gray-300 border-solid rounded-md shadow-sm focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
-                    {{ form.wallet_public_key.errors }}
-                    <label class="absolute inline-block px-1 -mt-1 font-medium text-gray-900 bg-gray-100 text-md -top-2 left-2"
-                           for="{{ form.wallet_public_key.id_for_label }}">
-                        Wallet Address (Public Key)
-                    </label>
-                    {{ form.wallet_public_key }}
-                </div>
-                <div class="relative px-3 py-2 border border-gray-300 border-solid rounded-md shadow-sm focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
-                    {{ form.date_requested.errors }}
-                    <label class="absolute inline-block px-1 -mt-1 font-medium text-gray-900 bg-gray-100 text-md -top-2 left-2"
-                           for="{{ form.date_requested.id_for_label }}">
-                        Date you would like
-                    </label>
-                    {{ form.date_requested }}
-                </div>
-            </div>
-            <button type="submit"
-                    class="inline-flex items-center px-4 py-2 text-sm font-medium text-indigo-700 bg-indigo-100 border border-transparent border-solid rounded-md hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                Submit
-            </button>
-        </form>
-    </div>
-    <div class="mb-10">
-        <h2 class="prose lg:prose-lg">
-            Dates Already Requsted ({{ dates_requested | length }})
-        </h2>
-        <div class="flex flex-col">
-            <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-                <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-                    <div class="overflow-hidden border-b border-gray-200 border-solid shadow sm:rounded-lg">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
+
+        <div class="bw-surface overflow-hidden">
+          {% if dates_requested %}
+            <div class="overflow-x-auto">
+              <table class="min-w-[36rem] w-full divide-y divide-[var(--bw-border)]">
+                            <thead class="bg-[var(--bw-surface-raised)]">
                                 <tr>
                                     <th scope="col"
-                                        class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
+                                        class="px-5 py-3 text-left text-xs font-black uppercase text-[var(--bw-ink-soft)]">
                                         Date
                                     </th>
                                     <th scope="col"
-                                        class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
+                                        class="px-5 py-3 text-left text-xs font-black uppercase text-[var(--bw-ink-soft)]">
                                         Sent
                                     </th>
                                     <th scope="col"
-                                        class="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
+                                        class="px-5 py-3 text-left text-xs font-black uppercase text-[var(--bw-ink-soft)]">
                                         Proof
                                     </th>
                                 </tr>
                             </thead>
-                            <tbody>
+                            <tbody class="divide-y divide-[var(--bw-border)] bg-[var(--bw-surface)]">
                                 {% for object in dates_requested %}
-                                    <tr class="bg-white">
-                                        <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">
+                                    <tr>
+                                        <td class="px-5 py-4 text-sm font-bold text-[var(--bw-ink)] whitespace-nowrap">
                                             {% if object.link %}
-                                                <a class="text-blue-600 underline"
+                                                <a class="font-black text-[var(--bw-primary-dark)] underline underline-offset-2"
                                                    target="_blank"
+                                                   rel="noopener"
                                                    href="{{ object.link }}">
                                                     {{ object.date_requested }}
                                                 </a>
@@ -143,32 +139,39 @@
                                                 {{ object.date_requested }}
                                             {% endif %}
                                         </td>
-                                        <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
+                                        <td class="px-5 py-4 text-sm whitespace-nowrap">
                                             {% if object.sent %}
-                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                                <span class="inline-flex items-center rounded-md bg-[var(--bw-primary-soft)] px-2.5 py-1 text-xs font-black text-[var(--bw-primary-dark)]">
                                                     Yes
                                                 </span>
                                             {% else %}
-                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                                                <span class="inline-flex items-center rounded-md bg-[oklch(95%_0.04_28)] px-2.5 py-1 text-xs font-black text-[var(--bw-danger)]">
                                                     No
                                                 </span>
                                             {% endif %}
                                         </td>
-                                        <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">
+                                        <td class="px-5 py-4 text-sm font-bold text-[var(--bw-ink)] whitespace-nowrap">
                                             {% if object.proof %}
-                                                <a class="inline-flex items-center px-2.5 py-1.5 border border-solid border-transparent text-xs font-medium rounded shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                                                <a class="bw-button bw-button-secondary min-h-[2.75rem] px-3 py-2 text-xs"
                                                    href="{{ object.proof }}">
                                                     Link
                                                 </a>
+                                            {% else %}
+                                                <span class="bw-muted">Pending</span>
                                             {% endif %}
                                         </td>
                                     </tr>
-                                </tbody>
-                            {% endfor %}
-                        </table>
-                    </div>
-                </div>
+                                {% endfor %}
+                            </tbody>
+              </table>
             </div>
+          {% else %}
+            <div class="p-6 text-center">
+              <p class="text-lg font-black text-[var(--bw-ink)]">No dates have been requested yet.</p>
+              <p class="mx-auto mt-2 max-w-md text-sm bw-muted">Submit the first request above.</p>
+            </div>
+          {% endif %}
         </div>
-    </div>
+      </div>
+    </section>
 {% endblock content %}

--- a/templates/projects/all_projects.html
+++ b/templates/projects/all_projects.html
@@ -8,18 +8,8 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero">
-  <div class="bw-container grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end">
-    <div>
-      <p class="bw-kicker">Project directory</p>
-      <h1 class="bw-heading-lg mt-3">Django projects worth studying</h1>
-      <p class="bw-lede mt-5">
-        Browse real products, side projects, open source apps, and businesses built with Django. Use them for inspiration, research, and proof that Django can ship.
-      </p>
-    </div>
-    <a href="{% url 'submit_project' %}" class="bw-button bw-button-accent">Submit a project</a>
-  </div>
-</section>
+{% url 'submit_project' as submit_project_url %}
+{% include "components/page-hero.html" with kicker="Project directory" title="Django projects worth studying" description="Browse real products, side projects, open source apps, and businesses built with Django. Use them for inspiration, research, and proof that Django can ship." cta_url=submit_project_url cta_label="Submit a project" %}
 
 <section class="pb-16">
   <div class="bw-container">
@@ -30,7 +20,7 @@
                   data-action="dropdown#toggle click@window->dropdown#hide"
                   class="bw-button bw-button-secondary w-full md:w-auto"
                   id="menu-button"
-                  aria-expanded="true"
+                  aria-expanded="false"
                   aria-haspopup="true">
             <i class="las la-filter" aria-hidden="true"></i>
             Filter
@@ -48,13 +38,13 @@
                aria-labelledby="menu-button">
             <form class="grid gap-4" action="" method="get">
               <div>
-                <label class="block text-sm font-black text-[var(--bw-ink)]">Open source</label>
-                {% render_field filter.form.is_open_source class="mt-1 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-sm focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" %}
+                <label class="bw-form-label">Open source</label>
+                {% render_field filter.form.is_open_source class="bw-form-input mt-1 text-sm" %}
               </div>
               <div>
                 {% with order_by=request.GET.order_by|default:'updated_date' %}
-                  <label for="order_by" class="block text-sm font-black text-[var(--bw-ink)]">Sort by</label>
-                  <select id="order_by" name="order_by" class="mt-1 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-sm focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]">
+                  <label for="order_by" class="bw-form-label">Sort by</label>
+                  <select id="order_by" name="order_by" class="bw-form-input mt-1 text-sm">
                     <option value="updated_date" {% if order_by == 'updated_date' %}selected{% endif %}>Recently updated</option>
                     <option value="like" {% if order_by == 'like' %}selected{% endif %}>Most liked</option>
                   </select>

--- a/templates/projects/submit-project.html
+++ b/templates/projects/submit-project.html
@@ -8,13 +8,7 @@
 {% endblock meta %}
 
 {% block content %}
-<section class="bw-page-hero pb-10">
-  <div class="bw-container">
-    <p class="bw-kicker">Add to the showcase</p>
-    <h1 class="bw-heading-lg mt-3">Submit a Django project</h1>
-    <p class="bw-lede mt-5">Share what you built so people using Django can learn from it, use it, and send useful attention back to the project.</p>
-  </div>
-</section>
+{% include "components/page-hero.html" with section_class="pb-10" kicker="Add to the showcase" title="Submit a Django project" description="Share what you built so people using Django can learn from it, use it, and send useful attention back to the project." %}
 
 <section class="pb-16">
   <div class="bw-container">
@@ -32,18 +26,18 @@
           <div class="grid gap-5">
             <div>
               {{ form.title.errors | safe }}
-              <label for="title" class="block text-sm font-black text-[var(--bw-ink)]">Project title</label>
-              {% render_field form.title class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="My Django App" %}
+              <label for="title" class="bw-form-label">Project title</label>
+              {% render_field form.title class="bw-form-input text-base" placeholder="My Django App" %}
             </div>
             <div>
               {{ form.url.errors | safe }}
-              <label for="url" class="block text-sm font-black text-[var(--bw-ink)]">Project URL</label>
-              {% render_field form.url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://example.com" %}
+              <label for="url" class="bw-form-label">Project URL</label>
+              {% render_field form.url class="bw-form-input text-base" placeholder="https://example.com" %}
             </div>
             <div>
               {{ form.short_description.errors | safe }}
-              <label for="short_description" class="block text-sm font-black text-[var(--bw-ink)]">Short description</label>
-              {% render_field form.short_description class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="What does it do, and who is it for?" %}
+              <label for="short_description" class="bw-form-label">Short description</label>
+              {% render_field form.short_description class="bw-form-input text-base" placeholder="What does it do, and who is it for?" %}
               <p class="mt-2 text-sm bw-muted">A few useful sentences, up to 200 characters.</p>
             </div>
           </div>
@@ -57,19 +51,19 @@
             <div class="grid gap-5 sm:grid-cols-2">
               <div>
                 {{ form.twitter_url.errors | safe }}
-                <label for="twitter_url" class="block text-sm font-black text-[var(--bw-ink)]">X/Twitter URL</label>
-                {% render_field form.twitter_url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://twitter.com/builtwithdjango" %}
+                <label for="twitter_url" class="bw-form-label">X/Twitter URL</label>
+                {% render_field form.twitter_url class="bw-form-input text-base" placeholder="https://twitter.com/builtwithdjango" %}
               </div>
               <div>
                 {{ form.github_url.errors | safe }}
-                <label for="github_url" class="block text-sm font-black text-[var(--bw-ink)]">GitHub URL</label>
-                {% render_field form.github_url class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" placeholder="https://github.com/example/repo" %}
+                <label for="github_url" class="bw-form-label">GitHub URL</label>
+                {% render_field form.github_url class="bw-form-input text-base" placeholder="https://github.com/example/repo" %}
               </div>
             </div>
             <div>
               {{ form.technology_suggestions_by_user.errors | safe }}
-              <label for="technology_suggestions_by_user" class="block text-sm font-black text-[var(--bw-ink)]">Technologies used</label>
-              {% render_field form.technology_suggestions_by_user class="mt-2 block w-full rounded-md border-[var(--bw-border)] bg-[var(--bw-surface)] text-base focus:border-[var(--bw-primary)] focus:ring-[var(--bw-primary)]" rows=5 placeholder="Django, HTMX, Tailwind, Postgres..." %}
+              <label for="technology_suggestions_by_user" class="bw-form-label">Technologies used</label>
+              {% render_field form.technology_suggestions_by_user class="bw-form-input text-base" rows=5 placeholder="Django, HTMX, Tailwind, Postgres..." %}
             </div>
           </div>
 

--- a/templates/tools/format_html.html
+++ b/templates/tools/format_html.html
@@ -6,29 +6,36 @@
 {% endblock meta %}
 
 {% block content %}
-<div data-controller="html-formatter" class="container px-4 py-8 mx-auto max-w-7xl">
-    <h1 class="mb-6 text-3xl font-bold text-center">Django HTML Template Formatter</h1>
-    <div class="flex flex-col gap-6 md:flex-row">
-        <div class="flex-1">
-            <h2 class="mb-2 text-xl font-semibold">Input HTML</h2>
+<section data-controller="html-formatter" class="bw-section">
+  <div class="bw-container-wide">
+    <h1 class="bw-heading-md text-center">Django HTML Template Formatter</h1>
+    <p data-html-formatter-target="status" class="mx-auto mt-3 max-w-2xl text-center text-sm bw-muted" role="status" aria-live="polite">
+      Paste a Django template, format it, then copy the result.
+    </p>
+    <div class="mt-8 flex flex-col gap-6 md:flex-row">
+        <div class="min-w-0 flex-1">
+            <label for="formatter-input" class="bw-form-label text-base font-black text-[var(--bw-ink)]">Input HTML</label>
             <textarea
+                id="formatter-input"
                 data-html-formatter-target="input"
                 placeholder="Enter your HTML here..."
-                class="p-3 w-full h-96 font-mono text-sm rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-green-500"
+                class="bw-form-input h-96 font-mono text-sm leading-6"
             ></textarea>
         </div>
-        <div class="relative flex-1">
-            <h2 class="mb-2 text-xl font-semibold">Formatted HTML</h2>
+        <div class="relative min-w-0 flex-1">
+            <label for="formatter-result" class="bw-form-label text-base font-black text-[var(--bw-ink)]">Formatted HTML</label>
             <textarea
+                id="formatter-result"
                 data-html-formatter-target="result"
                 readonly
-                class="p-3 w-full h-96 font-mono text-sm bg-gray-50 rounded-md border border-gray-300"
+                class="bw-form-input h-96 bg-[var(--bw-surface-raised)] pb-16 font-mono text-sm leading-6"
             ></textarea>
             <button
               type="button"
               data-action="click->html-formatter#copy"
               data-html-formatter-target="copyButton"
-              class="absolute right-2 bottom-2 px-3 py-1 text-sm font-medium text-white bg-green-500 rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+              class="bw-button bw-button-secondary absolute bottom-2 right-2 text-sm"
+              disabled
             >
               Copy
             </button>
@@ -39,12 +46,13 @@
             type="button"
             data-action="click->html-formatter#formatHTML"
             data-html-formatter-target="submitButton"
-            class="px-6 py-2 font-semibold text-white bg-green-500 rounded-md hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+            class="bw-button bw-button-primary"
         >
             Format HTML
         </button>
     </div>
-</div>
+  </div>
+</section>
 
 {% include "components/newsletter.html" with newsletter_form=newsletter_form %}
 

--- a/templates/tools/generate_django_secret.html
+++ b/templates/tools/generate_django_secret.html
@@ -7,36 +7,50 @@
 {% endblock meta %}
 
 {% block content %}
-<div
+<section
   data-controller="secret-key"
   data-secret-key-url-value="{% url 'generate_django_secret' %}"
-  class="px-6 py-20 bg-white lg:px-8"
+  class="bw-section"
 >
-  <div class="mx-auto max-w-2xl text-center">
-    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Generate Django Secret</h1>
-    <p class="mt-6 text-lg leading-8 text-gray-600 prose">
-      If you want to learn best practices of using secrets in Django, check out <a href="/blog/env-vars">this post</a>.
-    </p>
-  </div>
-  <div class="flex flex-col items-center mt-8">
-    <div class="mb-4 w-full max-w-lg">
-      <div class="flex items-center p-1 rounded-md border border-gray-300 focus-within:border-green-500 focus-within:ring-1 focus-within:ring-green-500">
-        <input
-          data-secret-key-target="output"
-          readonly
-          class="flex-grow p-2 text-sm text-gray-600 rounded-l-md border-0 focus:ring-0 outline-0 focus:outline-0"
-          type="text"
-          placeholder="Your secret key will appear here"
-        />
-        <button data-secret-key-target="copyButton" data-action="secret-key#copy" class="px-4 py-2 text-sm text-white bg-green-600 rounded-md transition-colors hover:bg-green-500">Copy</button>
-      </div>
+  <div class="bw-container">
+    <div class="mx-auto max-w-2xl text-center">
+      <h1 class="bw-heading-lg">Generate Django Secret</h1>
+      <p class="bw-lede mx-auto mt-6">
+        If you want to learn best practices of using secrets in Django, check out <a href="/blog/env-vars">this post</a>.
+      </p>
     </div>
-    <button
-      data-action="click->secret-key#generate"
-      class="px-5 py-3 text-base font-medium text-white bg-green-500 rounded-md border border-transparent shadow transition-colors hover:bg-green-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-green-700 focus:ring-white"
-    >Generate Secret Key</button>
+    <div class="mt-8 flex flex-col items-center">
+      <div class="w-full max-w-lg">
+        <label for="generated-secret-key" class="sr-only">Generated secret key</label>
+        <div class="flex min-w-0 items-center gap-2 rounded-md border border-[var(--bw-border)] bg-[var(--bw-surface)] p-1 shadow-sm focus-within:border-[var(--bw-primary)] focus-within:ring-2 focus-within:ring-[oklch(51%_0.15_151_/_0.18)]">
+          <input
+            id="generated-secret-key"
+            data-secret-key-target="output"
+            readonly
+            class="min-h-[2.75rem] min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-sm text-[var(--bw-ink)] focus:outline-none focus:ring-0"
+            type="text"
+            aria-describedby="secret-key-status"
+            placeholder="Your secret key will appear here"
+          />
+          <button type="button"
+                  data-secret-key-target="copyButton"
+                  data-action="secret-key#copy"
+                  class="bw-button bw-button-secondary shrink-0 text-sm"
+                  disabled>Copy</button>
+        </div>
+        <p id="secret-key-status" data-secret-key-target="status" class="mt-3 text-sm bw-muted" role="status" aria-live="polite">
+          Generate a key, then copy it into your environment file.
+        </p>
+      </div>
+      <button
+        type="button"
+        data-secret-key-target="generateButton"
+        data-action="click->secret-key#generate"
+        class="bw-button bw-button-primary mt-5"
+      >Generate Secret Key</button>
+    </div>
   </div>
-</div>
+</section>
 
 {% include "components/newsletter.html" with newsletter_form=newsletter_form %}
 


### PR DESCRIPTION
## Summary
- harden shared UI primitives, navigation/dropdown behavior, forms, and newsletter surfaces
- extract reusable page hero, inline form, search, footer, webring, and ad component styles
- optimize frontend controllers, Sentry loading, webpack behavior, and the bottom ad reveal lifecycle
- polish key public templates for labels, mobile fit, touch targets, empty states, and responsive layout

## Verification
- npm run build
- DJANGO_SETTINGS_MODULE=builtwithdjango.test_settings DJANGO_TEST_USE_DATABASE_URL=true DATABASE_URL=sqlite:////tmp/bwd-pr-check.sqlite3 .venv/bin/python manage.py check
- git diff --check
- responsive browser verification for bottom ad reveal/close behavior at 390x844 and 1280x900