### PR TITLE
[Blog] Align Blog Post Content

### DIFF
--- a/templates/blog/post_detail.html
+++ b/templates/blog/post_detail.html
@@ -29,8 +29,8 @@
 <div data-controller="exit-intent" data-action="mouseout@document->exit-intent#openModal">
 {# djlint:on #}
   <section class="pb-16">
-    <div class="bw-container max-w-4xl">
-      <article class="bw-surface p-5 sm:p-8">
+    <div class="bw-container">
+      <article class="bw-surface max-w-4xl p-5 sm:p-8">
         <div class="bw-prose prose max-w-none md:prose-lg">
           <div class="blog-post">
             {{ object.content | markdown | safe }}


### PR DESCRIPTION
## Summary
- Align the blog post article card with the blog hero container.
- Keep the article card constrained to the existing readable width.

## Testing
- git diff --check
- pre-commit djLint linting for Django passed during commit

## Notes
- Local pytest and frontend build were not run before PR creation because this worktree did not have Python test dependencies or node_modules installed.